### PR TITLE
Add security scanning and dependency audit to CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,38 @@ jobs:
       - name: Run mypy
         run: mypy proton-email-server.py
 
+  security:
+    name: Security Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install bandit
+      - name: Run bandit
+        run: bandit -r . -f json -o bandit-report.json --exit-zero
+      - name: Display results
+        run: bandit -r . -ll
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bandit-report
+          path: bandit-report.json
+
+  dependency-audit:
+    name: Dependency Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install pip-audit -r requirements.txt
+      - name: Run pip-audit
+        run: pip-audit -r requirements.txt
+
   syntax:
     name: Syntax Check
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    name: Lint & Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install ruff
+      - name: Check formatting
+        run: ruff format --check .
+      - name: Lint
+        run: ruff check .
+
+  typecheck:
+    name: Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install -r requirements.txt -r requirements-dev.txt
+      - name: Run mypy
+        run: mypy proton-email-server.py
+
+  syntax:
+    name: Syntax Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Verify Python syntax
+        run: python -c "import ast; ast.parse(open('proton-email-server.py').read()); print('OK')"

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 __pycache__/
+.env
+*.env
+venv/
+filter_rules.json

--- a/proton-email-server.py
+++ b/proton-email-server.py
@@ -17,7 +17,6 @@ from urllib.parse import urlparse
 import requests
 from dotenv import load_dotenv
 from mcp.server.fastmcp import FastMCP
-from mcp.types import Resource
 
 # Load environment variables
 load_dotenv()
@@ -36,11 +35,11 @@ class ProtonEmailClient:
         self.imap_port = int(os.getenv("BRIDGE_IMAP_PORT", "1143"))
         self.smtp_host = os.getenv("BRIDGE_SMTP_HOST", "127.0.0.1")
         self.smtp_port = int(os.getenv("BRIDGE_SMTP_PORT", "1025"))
-        self.email = os.getenv("PROTON_EMAIL")
-        self.password = os.getenv("PROTON_BRIDGE_PASSWORD")
+        self.email: str = os.getenv("PROTON_EMAIL", "")
+        self.password: str = os.getenv("PROTON_BRIDGE_PASSWORD", "")
         self.rules_file = os.path.join(os.path.dirname(__file__), "filter_rules.json")
 
-        if not all([self.email, self.password]):
+        if not self.email or not self.password:
             raise ValueError("Email credentials not found in environment variables")
 
     @staticmethod
@@ -158,13 +157,15 @@ class ProtonEmailClient:
 
                 if content_type == "text/plain" and "attachment" not in content_disposition:
                     try:
-                        body = part.get_payload(decode=True).decode("utf-8", errors="ignore")
+                        raw = part.get_payload(decode=True)
+                        body = raw.decode("utf-8", errors="ignore") if isinstance(raw, bytes) else ""
                         break
                     except Exception:
                         continue
         else:
             try:
-                body = email_message.get_payload(decode=True).decode("utf-8", errors="ignore")
+                raw = email_message.get_payload(decode=True)
+                body = raw.decode("utf-8", errors="ignore") if isinstance(raw, bytes) else ""
             except Exception:
                 body = str(email_message.get_payload())
 
@@ -337,7 +338,7 @@ class ProtonEmailClient:
                                                 if "attachment" not in content_disposition:
                                                     try:
                                                         payload = part.get_payload(decode=True)
-                                                        if payload:
+                                                        if isinstance(payload, bytes):
                                                             content = payload.decode("utf-8", errors="ignore")
                                                             if content_type == "text/plain":
                                                                 text_content += content
@@ -348,7 +349,7 @@ class ProtonEmailClient:
                                         else:
                                             try:
                                                 payload = email_message.get_payload(decode=True)
-                                                if payload:
+                                                if isinstance(payload, bytes):
                                                     content = payload.decode("utf-8", errors="ignore")
                                                     if email_message.get_content_type() == "text/html":
                                                         html_content = content
@@ -383,12 +384,12 @@ class ProtonEmailClient:
 
         return emails
 
-    def send_email(self, to: str, subject: str, body: str, reply_to_id: str = None):
+    def send_email(self, to: str, subject: str, body: str, reply_to_id: str | None = None):
         """Send email via SMTP"""
         server = self.connect_smtp()
         try:
             msg = MIMEMultipart()
-            msg["From"] = self.email
+            msg["From"] = str(self.email)
             msg["To"] = to
             msg["Subject"] = subject
 
@@ -798,18 +799,19 @@ class ProtonEmailClient:
         finally:
             mail.logout()
 
-    def load_filter_rules(self) -> list[dict]:
+    def load_filter_rules(self) -> list[dict[str, Any]]:
         """Load filtering rules from JSON file"""
         try:
             if os.path.exists(self.rules_file):
                 with open(self.rules_file) as f:
-                    return json.load(f)
+                    rules: list[dict[str, Any]] = json.load(f)
+                    return rules
             return []
         except Exception as e:
             logger.error(f"Failed to load filter rules: {e}")
             return []
 
-    def save_filter_rules(self, rules: list[dict]) -> bool:
+    def save_filter_rules(self, rules: list[dict[str, Any]]) -> bool:
         """Save filtering rules to JSON file"""
         try:
             with open(self.rules_file, "w") as f:
@@ -998,7 +1000,7 @@ class ProtonEmailClient:
             return {"error": "Failed to retrieve email content"}
 
         # Group actions by type for bulk execution
-        bulk_actions = {
+        bulk_actions: dict[str, Any] = {
             "move_to_folder": {},  # {target_folder: [email_ids]}
             "mark_as_read": [],
             "mark_as_important": [],
@@ -1150,7 +1152,7 @@ class ProtonEmailClient:
             return {"emails_processed": 0, "actions_taken": 0, "bulk_results": {}}
 
         # Group actions for bulk execution
-        bulk_actions = {"move_to_folder": {}, "mark_as_read": [], "mark_as_important": [], "delete": []}
+        bulk_actions: dict[str, Any] = {"move_to_folder": {}, "mark_as_read": [], "mark_as_important": [], "delete": []}
 
         # Process emails against rules
         for email_id, full_email in full_emails.items():
@@ -1228,7 +1230,7 @@ class ProtonEmailClient:
                     if "attachment" not in content_disposition:
                         try:
                             payload = part.get_payload(decode=True)
-                            if payload:
+                            if isinstance(payload, bytes):
                                 content = payload.decode("utf-8", errors="ignore")
                                 if content_type == "text/plain":
                                     text_content += content
@@ -1239,7 +1241,7 @@ class ProtonEmailClient:
             else:
                 try:
                     payload = email_message.get_payload(decode=True)
-                    if payload:
+                    if isinstance(payload, bytes):
                         content = payload.decode("utf-8", errors="ignore")
                         if email_message.get_content_type() == "text/html":
                             html_content = content
@@ -1399,7 +1401,7 @@ class ProtonEmailClient:
         """
         Execute an unsubscribe request.
         """
-        result = {"method": unsubscribe_method, "success": False, "message": "", "status_code": None}
+        result: dict[str, Any] = {"method": unsubscribe_method, "success": False, "message": "", "status_code": None}
 
         try:
             if unsubscribe_method["type"] == "mailto":
@@ -1484,7 +1486,7 @@ email_client = ProtonEmailClient()
 
 # MCP Tools
 @mcp.tool()
-def search_emails(query: str = "ALL", mailbox: str = "INBOX", limit: int = 10) -> list[dict]:
+def search_emails(query: str = "ALL", mailbox: str = "INBOX", limit: int = 10) -> Any:
     """
     Search for emails in your Proton mailbox.
 
@@ -1503,7 +1505,7 @@ def search_emails(query: str = "ALL", mailbox: str = "INBOX", limit: int = 10) -
 
 
 @mcp.tool()
-def get_email_content(email_id: str, mailbox: str = "INBOX") -> dict:
+def get_email_content(email_id: str, mailbox: str = "INBOX") -> dict[str, Any]:
     """
     Get the full content of a specific email.
 
@@ -1520,7 +1522,7 @@ def get_email_content(email_id: str, mailbox: str = "INBOX") -> dict:
         return {"error": str(e)}
 
     try:
-        email_data = email_client.get_full_email(email_id, mailbox)
+        email_data: dict[str, Any] = email_client.get_full_email(email_id, mailbox)
         if email_data:
             return email_data
         else:
@@ -1530,7 +1532,7 @@ def get_email_content(email_id: str, mailbox: str = "INBOX") -> dict:
 
 
 @mcp.tool()
-def send_email(to: str, subject: str, body: str, reply_to_id: str = None) -> dict:
+def send_email(to: str, subject: str, body: str, reply_to_id: str | None = None) -> dict:
     """
     Send an email via Proton Mail.
 
@@ -1554,7 +1556,7 @@ def send_email(to: str, subject: str, body: str, reply_to_id: str = None) -> dic
 
 
 @mcp.tool()
-def get_recent_emails(days: int = 7, mailbox: str = "INBOX") -> list[dict]:
+def get_recent_emails(days: int = 7, mailbox: str = "INBOX") -> Any:
     """
     Get recent emails from the specified number of days.
 
@@ -1574,7 +1576,7 @@ def get_recent_emails(days: int = 7, mailbox: str = "INBOX") -> list[dict]:
 
 
 @mcp.tool()
-def filter_junk_emails(mailbox: str = "INBOX", limit: int = 20, action: str = "analyze") -> list[dict]:
+def filter_junk_emails(mailbox: str = "INBOX", limit: int = 20, action: str = "analyze") -> Any:
     """
     Filter and analyze emails for junk/spam content using optimized bulk operations.
 
@@ -1691,7 +1693,7 @@ def move_email_to_folder(email_id: str, target_folder: str, source_folder: str =
 
 
 @mcp.tool()
-def get_mailboxes() -> list[str]:
+def get_mailboxes() -> Any:
     """
     Get list of available mailboxes/folders.
 
@@ -1798,7 +1800,7 @@ def analyze_email_for_junk(email_id: str, mailbox: str = "INBOX") -> dict:
 @mcp.tool()
 def search_emails_filtered(
     query: str = "ALL", mailbox: str = "INBOX", limit: int = 10, exclude_junk: bool = False
-) -> list[dict]:
+) -> Any:
     """
     Search for emails with optional junk filtering.
 
@@ -1820,7 +1822,7 @@ def search_emails_filtered(
             return emails
 
         # Filter out junk emails
-        filtered_emails = []
+        filtered_emails: list[dict] = []
         for email_item in emails:
             if len(filtered_emails) >= limit:
                 break
@@ -1923,7 +1925,7 @@ def unsubscribe_from_email(email_id: str, mailbox: str = "INBOX", method_index: 
 
 
 @mcp.tool()
-def bulk_find_unsubscribe_opportunities(mailbox: str = "INBOX", days: int = 30, limit: int = 50) -> list[dict]:
+def bulk_find_unsubscribe_opportunities(mailbox: str = "INBOX", days: int = 30, limit: int = 50) -> Any:
     """
     Scan recent emails to find unsubscribe opportunities from mailing lists using bulk operations.
 
@@ -1996,7 +1998,7 @@ def bulk_find_unsubscribe_opportunities(mailbox: str = "INBOX", days: int = 30, 
 
 
 @mcp.tool()
-def get_mailing_list_senders(mailbox: str = "INBOX", days: int = 30, min_emails: int = 2) -> list[dict]:
+def get_mailing_list_senders(mailbox: str = "INBOX", days: int = 30, min_emails: int = 2) -> Any:
     """
     Identify frequent senders that might be mailing lists.
 
@@ -2097,7 +2099,7 @@ def create_filter_rule(rule_name: str, conditions: str, actions: str, enabled: b
 
 
 @mcp.tool()
-def list_filter_rules() -> list[dict]:
+def list_filter_rules() -> Any:
     """
     Get list of all filtering rules.
 
@@ -2135,7 +2137,11 @@ def delete_filter_rule(rule_id: str) -> dict:
 
 @mcp.tool()
 def update_filter_rule(
-    rule_id: str, enabled: bool = None, rule_name: str = None, conditions: str = None, actions: str = None
+    rule_id: str,
+    enabled: bool | None = None,
+    rule_name: str | None = None,
+    conditions: str | None = None,
+    actions: str | None = None,
 ) -> dict:
     """
     Update an existing filtering rule.
@@ -2151,7 +2157,7 @@ def update_filter_rule(
         Status of rule update
     """
     try:
-        updates = {}
+        updates: dict[str, Any] = {}
 
         if enabled is not None:
             updates["enabled"] = enabled
@@ -2425,7 +2431,7 @@ def apply_filter_rules_optimized(mailbox: str = "INBOX", limit: int = 200, chunk
 
 
 @mcp.tool()
-def bulk_get_emails(email_ids: str, mailbox: str = "INBOX") -> list[dict]:
+def bulk_get_emails(email_ids: str, mailbox: str = "INBOX") -> Any:
     """
     Efficiently retrieve multiple emails in bulk.
 
@@ -2465,29 +2471,16 @@ def bulk_get_emails(email_ids: str, mailbox: str = "INBOX") -> list[dict]:
 
 # MCP Resources
 @mcp.resource("proton://inbox/summary")
-def inbox_summary() -> Resource:
+def inbox_summary() -> str:
     """Get a summary of your inbox"""
     try:
         recent_emails = email_client.search_emails("ALL", "INBOX", 5)
         summary = "Recent emails in your Proton inbox:\n\n"
         for email_item in recent_emails:
             summary += f"{email_item['subject']} - From: {email_item['from']} ({email_item['date']})\n"
-
-        return Resource(
-            uri="proton://inbox/summary",
-            name="Inbox Summary",
-            description="Summary of recent emails in your Proton inbox",
-            mimeType="text/plain",
-            text=summary,
-        )
+        return summary
     except Exception as e:
-        return Resource(
-            uri="proton://inbox/summary",
-            name="Inbox Summary",
-            description="Error retrieving inbox summary",
-            mimeType="text/plain",
-            text=f"Error: {str(e)}",
-        )
+        return f"Error: {str(e)}"
 
 
 # Run the server

--- a/proton-email-server.py
+++ b/proton-email-server.py
@@ -1,4 +1,3 @@
-import asyncio
 import imaplib
 import smtplib
 import email
@@ -10,10 +9,11 @@ import json
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
 from email.header import decode_header
-from typing import Any, List, Optional, Dict, Tuple
+from typing import Any, List, Optional, Dict
 from datetime import datetime, timedelta
 from urllib.parse import urljoin, urlparse
 import time
+import uuid
 
 from mcp.server.fastmcp import FastMCP
 from mcp.types import Resource, Tool, TextContent
@@ -136,12 +136,12 @@ class ProtonEmailClient:
                     try:
                         body = part.get_payload(decode=True).decode('utf-8', errors='ignore')
                         break
-                    except:
+                    except Exception:
                         continue
         else:
             try:
                 body = email_message.get_payload(decode=True).decode('utf-8', errors='ignore')
-            except:
+            except Exception:
                 body = str(email_message.get_payload())
         
         return body
@@ -312,7 +312,7 @@ class ProtonEmailClient:
                                                             text_content += content
                                                         elif content_type == "text/html":
                                                             html_content += content
-                                                except:
+                                                except Exception:
                                                     continue
                                     else:
                                         try:
@@ -323,7 +323,7 @@ class ProtonEmailClient:
                                                     html_content = content
                                                 else:
                                                     text_content = content
-                                        except:
+                                        except Exception:
                                             pass
                                     
                                     emails[email_id] = {
@@ -643,7 +643,7 @@ class ProtonEmailClient:
                                     marked_count += 1
                                 else:
                                     failed_count += 1
-                            except:
+                            except Exception:
                                 failed_count += 1
                 
                 except Exception as e:
@@ -656,7 +656,7 @@ class ProtonEmailClient:
                                 marked_count += 1
                             else:
                                 failed_count += 1
-                        except:
+                        except Exception:
                             failed_count += 1
         
         except Exception as e:
@@ -822,7 +822,7 @@ class ProtonEmailClient:
         
         # Create new rule
         new_rule = {
-            'id': str(len(rules) + 1),
+            'id': str(uuid.uuid4()),
             'name': rule_name,
             'conditions': conditions,
             'actions': actions,
@@ -861,7 +861,8 @@ class ProtonEmailClient:
     def email_matches_rule(self, email_data: Dict, rule: Dict) -> bool:
         """Check if an email matches a filtering rule's conditions"""
         conditions = rule.get('conditions', {})
-        
+        matches = True
+
         for condition, value in conditions.items():
             if condition == 'from':
                 if value.lower() not in email_data.get('from', '').lower():
@@ -885,12 +886,16 @@ class ProtonEmailClient:
                     return False
             elif condition == 'has_attachments':
                 # This would need to be implemented based on email structure
-                pass
+                logger.warning(f"Condition '{condition}' is not yet implemented, skipping email")
+                matches = False
+                break
             elif condition == 'older_than_days' or condition == 'newer_than_days':
                 # This would need date parsing and comparison
-                pass
-        
-        return True
+                logger.warning(f"Condition '{condition}' is not yet implemented, skipping email")
+                matches = False
+                break
+
+        return matches
     
     def apply_rule_actions(self, email_id: str, rule: Dict, mailbox: str = "INBOX") -> Dict[str, Any]:
         """Apply the actions specified in a filtering rule to an email"""
@@ -905,7 +910,7 @@ class ProtonEmailClient:
                 elif action == 'mark_as_read':
                     if value:  # Only if True
                         # Implementation would require IMAP STORE command
-                        results[action] = {'success': True, 'marked_read': True}
+                        results[action] = {'success': False, 'message': 'Not implemented for individual emails; use bulk operations'}
                 elif action == 'delete':
                     if value:  # Only if True
                         success = self.move_email_to_folder(email_id, 'Trash', mailbox)
@@ -913,7 +918,7 @@ class ProtonEmailClient:
                 elif action == 'mark_as_important':
                     if value:  # Only if True
                         # Implementation would require IMAP flag setting
-                        results[action] = {'success': True, 'marked_important': True}
+                        results[action] = {'success': False, 'message': 'Not implemented for individual emails; use bulk operations'}
                 # Forward and auto-reply would be more complex implementations
             except Exception as e:
                 results[action] = {'success': False, 'error': str(e)}
@@ -1185,7 +1190,7 @@ class ProtonEmailClient:
                                     text_content += content
                                 elif content_type == "text/html":
                                     html_content += content
-                        except:
+                        except Exception:
                             continue
             else:
                 try:
@@ -1196,7 +1201,7 @@ class ProtonEmailClient:
                             html_content = content
                         else:
                             text_content = content
-                except:
+                except Exception:
                     pass
             
             return {
@@ -2227,25 +2232,29 @@ def bulk_mark_emails_as_important(email_ids: str, mailbox: str = "INBOX", mark_i
         return {"error": f"Failed to bulk mark emails as important: {str(e)}"}
 
 @mcp.tool()
-def bulk_delete_emails(email_ids: str, mailbox: str = "INBOX", permanent: bool = False) -> dict:
+def bulk_delete_emails(email_ids: str, mailbox: str = "INBOX", permanent: bool = False, confirm: bool = False) -> dict:
     """
     Bulk delete emails (move to Trash or permanent deletion).
-    
+
     Args:
         email_ids: Comma-separated list of email IDs to delete
         mailbox: Source mailbox (default: INBOX)
         permanent: If True, permanently delete; if False, move to Trash
-    
+        confirm: Must be True when permanent=True as a safety measure
+
     Returns:
         Dictionary with deletion results
     """
     try:
+        if permanent and not confirm:
+            return {"error": "Safety measure: set confirm=True to permanently delete emails", "email_count": "unknown"}
+
         # Parse email IDs
         id_list = [id.strip() for id in email_ids.split(',') if id.strip()]
-        
+
         if not id_list:
             return {"error": "No valid email IDs provided"}
-        
+
         result = email_client.bulk_delete_emails(id_list, mailbox, permanent)
         
         return {

--- a/proton-email-server.py
+++ b/proton-email-server.py
@@ -12,7 +12,8 @@ from email.mime.multipart import MIMEMultipart
 from email.header import decode_header
 from typing import Any, List, Optional, Dict, Tuple
 from datetime import datetime, timedelta
-from urllib.parse import urljoin, urlparse
+from urllib.parse import urlparse
+import ipaddress
 import time
 
 from mcp.server.fastmcp import FastMCP
@@ -41,7 +42,28 @@ class ProtonEmailClient:
         
         if not all([self.email, self.password]):
             raise ValueError("Email credentials not found in environment variables")
-    
+
+    @staticmethod
+    def _validate_email_id(email_id: str) -> str:
+        """Validate email ID is numeric (single or comma-separated list)."""
+        email_id = email_id.strip()
+        if not re.match(r'^\d+(,\s*\d+)*$', email_id):
+            raise ValueError(f"Invalid email ID format: {email_id}")
+        return email_id
+
+    @staticmethod
+    def _validate_folder_name(folder_name: str) -> str:
+        """Validate folder name contains only safe characters."""
+        folder_name = folder_name.strip()
+        if not folder_name:
+            raise ValueError("Folder name cannot be empty")
+        # Allow alphanumeric, spaces, hyphens, underscores, dots, forward slashes (for nested folders)
+        if not re.match(r'^[\w\s\-./]+$', folder_name):
+            raise ValueError(f"Invalid folder name: {folder_name}")
+        if '..' in folder_name:
+            raise ValueError(f"Directory traversal not allowed in folder name: {folder_name}")
+        return folder_name
+
     def connect_imap(self):
         """Connect to IMAP server"""
         try:
@@ -216,21 +238,24 @@ class ProtonEmailClient:
                     
                     if status == 'OK' and msg_data:
                         # Process each email in the batch
-                        for j, item in enumerate(msg_data):
+                        for item in msg_data:
                             if isinstance(item, tuple) and len(item) >= 2:
-                                raw_email = item[1]
-                                if raw_email:
-                                    email_message = email.message_from_bytes(raw_email)
-                                    email_id = batch_ids[j // 2] if j % 2 == 1 else batch_ids[j]
-                                    
-                                    emails[email_id] = {
-                                        'id': email_id,
-                                        'subject': self.decode_mime_words(email_message['Subject']),
-                                        'from': self.decode_mime_words(email_message['From']),
-                                        'to': self.decode_mime_words(email_message['To']),
-                                        'date': email_message['Date'],
-                                        'body': self.get_email_body(email_message)
-                                    }
+                                # Parse sequence number from IMAP response header
+                                # Format: b'123 (RFC822 {size}' or b'123 (BODY[] {size}'
+                                header = item[0]
+                                if isinstance(header, bytes):
+                                    seq_num = header.split()[0].decode('ascii', errors='ignore')
+                                    raw_email = item[1]
+                                    if raw_email:
+                                        email_message = email.message_from_bytes(raw_email)
+                                        emails[seq_num] = {
+                                            'id': seq_num,
+                                            'subject': self.decode_mime_words(email_message['Subject']),
+                                            'from': self.decode_mime_words(email_message['From']),
+                                            'to': self.decode_mime_words(email_message['To']),
+                                            'date': email_message['Date'],
+                                            'body': self.get_email_body(email_message)
+                                        }
                 except Exception as e:
                     logger.warning(f"Failed to fetch batch {i//batch_size + 1}: {e}")
                     # Fallback to individual fetching for this batch
@@ -287,56 +312,60 @@ class ProtonEmailClient:
                     status, msg_data = mail.fetch(id_list, '(RFC822)')
                     
                     if status == 'OK' and msg_data:
-                        for j, item in enumerate(msg_data):
+                        for item in msg_data:
                             if isinstance(item, tuple) and len(item) >= 2:
-                                raw_email = item[1]
-                                if raw_email:
-                                    email_message = email.message_from_bytes(raw_email)
-                                    email_id = batch_ids[j // 2] if j % 2 == 1 else batch_ids[j]
+                                # Parse sequence number from IMAP response header
+                                # Format: b'123 (RFC822 {size}' or b'123 (BODY[] {size}'
+                                header = item[0]
+                                if isinstance(header, bytes):
+                                    seq_num = header.split()[0].decode('ascii', errors='ignore')
+                                    raw_email = item[1]
+                                    if raw_email:
+                                        email_message = email.message_from_bytes(raw_email)
                                     
-                                    # Extract both text and HTML content
-                                    text_content = ""
-                                    html_content = ""
+                                        # Extract both text and HTML content
+                                        text_content = ""
+                                        html_content = ""
                                     
-                                    if email_message.is_multipart():
-                                        for part in email_message.walk():
-                                            content_type = part.get_content_type()
-                                            content_disposition = str(part.get("Content-Disposition"))
-                                            
-                                            if "attachment" not in content_disposition:
-                                                try:
-                                                    payload = part.get_payload(decode=True)
-                                                    if payload:
-                                                        content = payload.decode('utf-8', errors='ignore')
-                                                        if content_type == "text/plain":
-                                                            text_content += content
-                                                        elif content_type == "text/html":
-                                                            html_content += content
-                                                except:
-                                                    continue
-                                    else:
-                                        try:
-                                            payload = email_message.get_payload(decode=True)
-                                            if payload:
-                                                content = payload.decode('utf-8', errors='ignore')
-                                                if email_message.get_content_type() == "text/html":
-                                                    html_content = content
-                                                else:
-                                                    text_content = content
-                                        except:
-                                            pass
-                                    
-                                    emails[email_id] = {
-                                        'id': email_id,
-                                        'subject': self.decode_mime_words(email_message['Subject']),
-                                        'from': self.decode_mime_words(email_message['From']),
-                                        'to': self.decode_mime_words(email_message['To']),
-                                        'date': email_message['Date'],
-                                        'text_body': text_content,
-                                        'html_body': html_content,
-                                        'list_unsubscribe': email_message.get('List-Unsubscribe', ''),
-                                        'list_unsubscribe_post': email_message.get('List-Unsubscribe-Post', '')
-                                    }
+                                        if email_message.is_multipart():
+                                            for part in email_message.walk():
+                                                content_type = part.get_content_type()
+                                                content_disposition = str(part.get("Content-Disposition"))
+                                                
+                                                if "attachment" not in content_disposition:
+                                                    try:
+                                                        payload = part.get_payload(decode=True)
+                                                        if payload:
+                                                            content = payload.decode('utf-8', errors='ignore')
+                                                            if content_type == "text/plain":
+                                                                text_content += content
+                                                            elif content_type == "text/html":
+                                                                html_content += content
+                                                    except:
+                                                        continue
+                                        else:
+                                            try:
+                                                payload = email_message.get_payload(decode=True)
+                                                if payload:
+                                                    content = payload.decode('utf-8', errors='ignore')
+                                                    if email_message.get_content_type() == "text/html":
+                                                        html_content = content
+                                                    else:
+                                                        text_content = content
+                                            except:
+                                                pass
+                                        
+                                        emails[seq_num] = {
+                                            'id': seq_num,
+                                            'subject': self.decode_mime_words(email_message['Subject']),
+                                            'from': self.decode_mime_words(email_message['From']),
+                                            'to': self.decode_mime_words(email_message['To']),
+                                            'date': email_message['Date'],
+                                            'text_body': text_content,
+                                            'html_body': html_content,
+                                            'list_unsubscribe': email_message.get('List-Unsubscribe', ''),
+                                            'list_unsubscribe_post': email_message.get('List-Unsubscribe-Post', '')
+                                        }
                 except Exception as e:
                     logger.warning(f"Failed to fetch HTML batch {i//batch_size + 1}: {e}")
                     # Fallback to individual fetching
@@ -1315,6 +1344,51 @@ class ProtonEmailClient:
             'has_one_click': any(method.get('one_click', False) for method in unique_methods)
         }
     
+    def _is_safe_url(self, url: str) -> bool:
+        """
+        Validate that a URL is safe to request (not targeting internal/private networks).
+        Returns True if the URL is safe, False otherwise.
+        """
+        try:
+            parsed = urlparse(url)
+        except Exception:
+            return False
+
+        # Only allow http and https schemes
+        if parsed.scheme not in ('http', 'https'):
+            logging.warning(f"Blocked URL with non-HTTP scheme: {parsed.scheme}")
+            return False
+
+        hostname = parsed.hostname
+        if not hostname:
+            return False
+
+        # Reject localhost variants
+        if hostname in ('localhost', 'localhost.localdomain'):
+            logging.warning(f"Blocked request to localhost: {url}")
+            return False
+
+        # Check if hostname is an IP address and validate it
+        try:
+            addr = ipaddress.ip_address(hostname)
+            if addr.is_loopback:
+                logging.warning(f"Blocked request to loopback address: {url}")
+                return False
+            if addr.is_private:
+                logging.warning(f"Blocked request to private IP range: {url}")
+                return False
+            if addr.is_link_local:
+                logging.warning(f"Blocked request to link-local address: {url}")
+                return False
+            if addr.is_reserved:
+                logging.warning(f"Blocked request to reserved address: {url}")
+                return False
+        except ValueError:
+            # Not an IP address, it's a hostname string - allow it but log
+            logging.debug(f"URL uses hostname (not IP): {hostname}")
+
+        return True
+
     def execute_unsubscribe(self, unsubscribe_method: Dict, timeout: int = 10) -> Dict[str, Any]:
         """
         Execute an unsubscribe request.
@@ -1335,7 +1409,12 @@ class ProtonEmailClient:
                 
             elif unsubscribe_method['type'] == 'http':
                 url = unsubscribe_method['url']
-                
+
+                # Validate URL before making any request
+                if not self._is_safe_url(url):
+                    result['message'] = f"Blocked unsafe unsubscribe URL: {url}"
+                    return result
+
                 # Set up headers to look like a real browser
                 headers = {
                     'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36',
@@ -1348,13 +1427,24 @@ class ProtonEmailClient:
                 if unsubscribe_method.get('one_click'):
                     # RFC 8058 one-click unsubscribe
                     headers['List-Unsubscribe'] = 'One-Click'
-                    response = requests.post(url, headers=headers, timeout=timeout, allow_redirects=True)
+                    response = requests.post(url, headers=headers, timeout=timeout, allow_redirects=False)
                 else:
                     # Regular HTTP GET request
-                    response = requests.get(url, headers=headers, timeout=timeout, allow_redirects=True)
+                    response = requests.get(url, headers=headers, timeout=timeout, allow_redirects=False)
                 
+                # Handle redirects safely
+                if response.status_code in (301, 302, 303, 307, 308):
+                    redirect_url = response.headers.get('Location')
+                    if redirect_url:
+                        if not self._is_safe_url(redirect_url):
+                            result['status_code'] = response.status_code
+                            result['message'] = f"Blocked unsafe redirect to: {redirect_url}"
+                            return result
+                        # Follow the safe redirect
+                        response = requests.get(redirect_url, headers=headers, timeout=timeout, allow_redirects=False)
+
                 result['status_code'] = response.status_code
-                
+
                 if response.status_code in [200, 201, 202, 204]:
                     result['success'] = True
                     result['message'] = f"Unsubscribe request successful (HTTP {response.status_code})"
@@ -1416,6 +1506,11 @@ def get_email_content(email_id: str, mailbox: str = "INBOX") -> dict:
     Returns:
         Full email content including subject, from, to, date, and complete body
     """
+    try:
+        email_id = email_client._validate_email_id(email_id)
+    except ValueError as e:
+        return {"error": str(e)}
+
     try:
         email_data = email_client.get_full_email(email_id, mailbox)
         if email_data:
@@ -1570,6 +1665,13 @@ def move_email_to_folder(email_id: str, target_folder: str, source_folder: str =
         Status of the move operation
     """
     try:
+        email_id = email_client._validate_email_id(email_id)
+        target_folder = email_client._validate_folder_name(target_folder)
+        source_folder = email_client._validate_folder_name(source_folder)
+    except ValueError as e:
+        return {"error": str(e)}
+
+    try:
         success = email_client.move_email_to_folder(email_id, target_folder, source_folder)
         if success:
             return {
@@ -1609,6 +1711,11 @@ def create_folder(folder_name: str) -> dict:
         Status of the folder creation operation
     """
     try:
+        folder_name = email_client._validate_folder_name(folder_name)
+    except ValueError as e:
+        return {"error": str(e)}
+
+    try:
         success = email_client.create_folder(folder_name)
         if success:
             return {
@@ -1634,6 +1741,11 @@ def delete_folder(folder_name: str) -> dict:
     Returns:
         Status of the folder deletion operation
     """
+    try:
+        folder_name = email_client._validate_folder_name(folder_name)
+    except ValueError as e:
+        return {"error": str(e)}
+
     try:
         success = email_client.delete_folder(folder_name)
         if success:
@@ -1661,6 +1773,11 @@ def analyze_email_for_junk(email_id: str, mailbox: str = "INBOX") -> dict:
     Returns:
         Detailed junk analysis for the email
     """
+    try:
+        email_id = email_client._validate_email_id(email_id)
+    except ValueError as e:
+        return {"error": str(e)}
+
     try:
         # Get full email content
         email_data = email_client.get_full_email(email_id, mailbox)
@@ -1734,6 +1851,11 @@ def find_unsubscribe_links(email_id: str, mailbox: str = "INBOX") -> dict:
         Dictionary with unsubscribe methods found
     """
     try:
+        email_id = email_client._validate_email_id(email_id)
+    except ValueError as e:
+        return {"error": str(e)}
+
+    try:
         # Get full email content with HTML
         email_data = email_client.get_full_email_with_html(email_id, mailbox)
         if not email_data:
@@ -1760,6 +1882,11 @@ def unsubscribe_from_email(email_id: str, mailbox: str = "INBOX", method_index: 
     Returns:
         Result of unsubscribe attempt
     """
+    try:
+        email_id = email_client._validate_email_id(email_id)
+    except ValueError as e:
+        return {"error": str(e)}
+
     try:
         if not confirm:
             return {
@@ -2143,6 +2270,13 @@ def bulk_move_emails(email_ids: str, target_folder: str, source_folder: str = "I
         Dictionary with move operation results
     """
     try:
+        email_ids = email_client._validate_email_id(email_ids)
+        target_folder = email_client._validate_folder_name(target_folder)
+        source_folder = email_client._validate_folder_name(source_folder)
+    except ValueError as e:
+        return {"error": str(e)}
+
+    try:
         # Parse email IDs
         id_list = [id.strip() for id in email_ids.split(',') if id.strip()]
         
@@ -2173,6 +2307,11 @@ def bulk_mark_emails_as_read(email_ids: str, mailbox: str = "INBOX", mark_read: 
     Returns:
         Dictionary with marking operation results
     """
+    try:
+        email_ids = email_client._validate_email_id(email_ids)
+    except ValueError as e:
+        return {"error": str(e)}
+
     try:
         # Parse email IDs
         id_list = [id.strip() for id in email_ids.split(',') if id.strip()]
@@ -2207,6 +2346,11 @@ def bulk_mark_emails_as_important(email_ids: str, mailbox: str = "INBOX", mark_i
         Dictionary with marking operation results
     """
     try:
+        email_ids = email_client._validate_email_id(email_ids)
+    except ValueError as e:
+        return {"error": str(e)}
+
+    try:
         # Parse email IDs
         id_list = [id.strip() for id in email_ids.split(',') if id.strip()]
         
@@ -2239,6 +2383,11 @@ def bulk_delete_emails(email_ids: str, mailbox: str = "INBOX", permanent: bool =
     Returns:
         Dictionary with deletion results
     """
+    try:
+        email_ids = email_client._validate_email_id(email_ids)
+    except ValueError as e:
+        return {"error": str(e)}
+
     try:
         # Parse email IDs
         id_list = [id.strip() for id in email_ids.split(',') if id.strip()]
@@ -2290,6 +2439,11 @@ def bulk_get_emails(email_ids: str, mailbox: str = "INBOX") -> List[dict]:
     Returns:
         List of email objects with full content
     """
+    try:
+        email_ids = email_client._validate_email_id(email_ids)
+    except ValueError as e:
+        return {"error": str(e)}
+
     try:
         # Parse email IDs
         id_list = [id.strip() for id in email_ids.split(',') if id.strip()]

--- a/proton-email-server.py
+++ b/proton-email-server.py
@@ -1,24 +1,23 @@
-import imaplib
-import smtplib
 import email
-import os
-import logging
-import re
-import requests
-import json
-from email.mime.text import MIMEText
-from email.mime.multipart import MIMEMultipart
-from email.header import decode_header
-from typing import Any, List, Optional, Dict
-from datetime import datetime, timedelta
-from urllib.parse import urlparse
+import imaplib
 import ipaddress
-import time
+import json
+import logging
+import os
+import re
+import smtplib
 import uuid
+from datetime import datetime, timedelta
+from email.header import decode_header
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from typing import Any
+from urllib.parse import urlparse
 
-from mcp.server.fastmcp import FastMCP
-from mcp.types import Resource, Tool, TextContent
+import requests
 from dotenv import load_dotenv
+from mcp.server.fastmcp import FastMCP
+from mcp.types import Resource
 
 # Load environment variables
 load_dotenv()
@@ -30,6 +29,7 @@ logger = logging.getLogger(__name__)
 # MCP Server instance
 mcp = FastMCP("ProtonEmailServer")
 
+
 class ProtonEmailClient:
     def __init__(self):
         self.imap_host = os.getenv("BRIDGE_IMAP_HOST", "127.0.0.1")
@@ -39,7 +39,7 @@ class ProtonEmailClient:
         self.email = os.getenv("PROTON_EMAIL")
         self.password = os.getenv("PROTON_BRIDGE_PASSWORD")
         self.rules_file = os.path.join(os.path.dirname(__file__), "filter_rules.json")
-        
+
         if not all([self.email, self.password]):
             raise ValueError("Email credentials not found in environment variables")
 
@@ -47,7 +47,7 @@ class ProtonEmailClient:
     def _validate_email_id(email_id: str) -> str:
         """Validate email ID is numeric (single or comma-separated list)."""
         email_id = email_id.strip()
-        if not re.match(r'^\d+(,\s*\d+)*$', email_id):
+        if not re.match(r"^\d+(,\s*\d+)*$", email_id):
             raise ValueError(f"Invalid email ID format: {email_id}")
         return email_id
 
@@ -58,9 +58,9 @@ class ProtonEmailClient:
         if not folder_name:
             raise ValueError("Folder name cannot be empty")
         # Allow alphanumeric, spaces, hyphens, underscores, dots, forward slashes (for nested folders)
-        if not re.match(r'^[\w\s\-./]+$', folder_name):
+        if not re.match(r"^[\w\s\-./]+$", folder_name):
             raise ValueError(f"Invalid folder name: {folder_name}")
-        if '..' in folder_name:
+        if ".." in folder_name:
             raise ValueError(f"Directory traversal not allowed in folder name: {folder_name}")
         return folder_name
 
@@ -73,7 +73,7 @@ class ProtonEmailClient:
         except Exception as e:
             logger.error(f"IMAP connection failed: {e}")
             raise
-    
+
     def connect_smtp(self):
         """Connect to SMTP server"""
         try:
@@ -84,7 +84,7 @@ class ProtonEmailClient:
         except Exception as e:
             logger.error(f"SMTP connection failed: {e}")
             raise
-    
+
     def decode_mime_words(self, text):
         """Decode MIME encoded words"""
         if text is None:
@@ -93,59 +93,61 @@ class ProtonEmailClient:
         decoded_text = ""
         for word, encoding in decoded_words:
             if isinstance(word, bytes):
-                word = word.decode(encoding or 'utf-8', errors='ignore')
+                word = word.decode(encoding or "utf-8", errors="ignore")
             decoded_text += word
         return decoded_text
-    
+
     def search_emails(self, query: str = "ALL", mailbox: str = "INBOX", limit: int = 10):
         """Search emails in specified mailbox"""
         mail = self.connect_imap()
         mailbox_selected = False
         try:
             status, response = mail.select(mailbox)
-            if status != 'OK':
+            if status != "OK":
                 logger.error(f"Failed to select mailbox '{mailbox}': {response}")
                 return []
             mailbox_selected = True
-            
+
             status, messages = mail.search(None, query)
-            
-            if status != 'OK':
+
+            if status != "OK":
                 return []
-            
+
             message_ids = messages[0].split()
             # Get most recent emails (reverse order)
             message_ids = message_ids[-limit:]
-            
+
             emails = []
             for msg_id in reversed(message_ids):
-                status, msg_data = mail.fetch(msg_id, '(RFC822)')
-                if status == 'OK':
+                status, msg_data = mail.fetch(msg_id, "(RFC822)")
+                if status == "OK":
                     raw_email = msg_data[0][1]
                     email_message = email.message_from_bytes(raw_email)
-                    
+
                     # Extract email details
-                    subject = self.decode_mime_words(email_message['Subject'])
-                    from_addr = self.decode_mime_words(email_message['From'])
-                    date = email_message['Date']
-                    
+                    subject = self.decode_mime_words(email_message["Subject"])
+                    from_addr = self.decode_mime_words(email_message["From"])
+                    date = email_message["Date"]
+
                     # Get email body
                     body = self.get_email_body(email_message)
-                    
-                    emails.append({
-                        'id': msg_id.decode(),
-                        'subject': subject,
-                        'from': from_addr,
-                        'date': date,
-                        'body': body[:500] + "..." if len(body) > 500 else body  # Truncate for preview
-                    })
-            
+
+                    emails.append(
+                        {
+                            "id": msg_id.decode(),
+                            "subject": subject,
+                            "from": from_addr,
+                            "date": date,
+                            "body": body[:500] + "..." if len(body) > 500 else body,  # Truncate for preview
+                        }
+                    )
+
             return emails
         finally:
             if mailbox_selected:
                 mail.close()
             mail.logout()
-    
+
     def get_email_body(self, email_message):
         """Extract email body text"""
         body = ""
@@ -153,90 +155,90 @@ class ProtonEmailClient:
             for part in email_message.walk():
                 content_type = part.get_content_type()
                 content_disposition = str(part.get("Content-Disposition"))
-                
+
                 if content_type == "text/plain" and "attachment" not in content_disposition:
                     try:
-                        body = part.get_payload(decode=True).decode('utf-8', errors='ignore')
+                        body = part.get_payload(decode=True).decode("utf-8", errors="ignore")
                         break
                     except Exception:
                         continue
         else:
             try:
-                body = email_message.get_payload(decode=True).decode('utf-8', errors='ignore')
+                body = email_message.get_payload(decode=True).decode("utf-8", errors="ignore")
             except Exception:
                 body = str(email_message.get_payload())
-        
+
         return body
-    
+
     def get_full_email(self, email_id: str, mailbox: str = "INBOX"):
         """Get full email content by ID"""
         mail = self.connect_imap()
         mailbox_selected = False
         try:
             status, response = mail.select(mailbox)
-            if status != 'OK':
+            if status != "OK":
                 logger.error(f"Failed to select mailbox '{mailbox}': {response}")
                 return None
             mailbox_selected = True
-            
-            status, msg_data = mail.fetch(email_id, '(RFC822)')
-            
-            if status != 'OK':
+
+            status, msg_data = mail.fetch(email_id, "(RFC822)")
+
+            if status != "OK":
                 return None
-            
+
             raw_email = msg_data[0][1]
             email_message = email.message_from_bytes(raw_email)
-            
+
             return {
-                'id': email_id,
-                'subject': self.decode_mime_words(email_message['Subject']),
-                'from': self.decode_mime_words(email_message['From']),
-                'to': self.decode_mime_words(email_message['To']),
-                'date': email_message['Date'],
-                'body': self.get_email_body(email_message)
+                "id": email_id,
+                "subject": self.decode_mime_words(email_message["Subject"]),
+                "from": self.decode_mime_words(email_message["From"]),
+                "to": self.decode_mime_words(email_message["To"]),
+                "date": email_message["Date"],
+                "body": self.get_email_body(email_message),
             }
         finally:
             if mailbox_selected:
                 mail.close()
             mail.logout()
-    
-    def get_bulk_emails(self, email_ids: List[str], mailbox: str = "INBOX", batch_size: int = 50):
+
+    def get_bulk_emails(self, email_ids: list[str], mailbox: str = "INBOX", batch_size: int = 50):
         """
         Get multiple emails efficiently in batches using IMAP pipelining.
-        
+
         Args:
             email_ids: List of email IDs to retrieve
             mailbox: Mailbox containing the emails
             batch_size: Number of emails to fetch per IMAP command
-        
+
         Returns:
             Dictionary mapping email_id to email data
         """
         if not email_ids:
             return {}
-        
+
         mail = self.connect_imap()
         emails = {}
         mailbox_selected = False
-        
+
         try:
             status, response = mail.select(mailbox)
-            if status != 'OK':
+            if status != "OK":
                 logger.error(f"Failed to select mailbox '{mailbox}': {response}")
                 return {}
             mailbox_selected = True
-            
+
             # Process emails in batches for efficiency
             for i in range(0, len(email_ids), batch_size):
-                batch_ids = email_ids[i:i + batch_size]
-                
+                batch_ids = email_ids[i : i + batch_size]
+
                 # Create comma-separated list for IMAP FETCH
-                id_list = ','.join(batch_ids)
-                
+                id_list = ",".join(batch_ids)
+
                 try:
-                    status, msg_data = mail.fetch(id_list, '(RFC822)')
-                    
-                    if status == 'OK' and msg_data:
+                    status, msg_data = mail.fetch(id_list, "(RFC822)")
+
+                    if status == "OK" and msg_data:
                         # Process each email in the batch
                         for item in msg_data:
                             if isinstance(item, tuple) and len(item) >= 2:
@@ -244,89 +246,89 @@ class ProtonEmailClient:
                                 # Format: b'123 (RFC822 {size}' or b'123 (BODY[] {size}'
                                 header = item[0]
                                 if isinstance(header, bytes):
-                                    seq_num = header.split()[0].decode('ascii', errors='ignore')
+                                    seq_num = header.split()[0].decode("ascii", errors="ignore")
                                     raw_email = item[1]
                                     if raw_email:
                                         email_message = email.message_from_bytes(raw_email)
                                         emails[seq_num] = {
-                                            'id': seq_num,
-                                            'subject': self.decode_mime_words(email_message['Subject']),
-                                            'from': self.decode_mime_words(email_message['From']),
-                                            'to': self.decode_mime_words(email_message['To']),
-                                            'date': email_message['Date'],
-                                            'body': self.get_email_body(email_message)
+                                            "id": seq_num,
+                                            "subject": self.decode_mime_words(email_message["Subject"]),
+                                            "from": self.decode_mime_words(email_message["From"]),
+                                            "to": self.decode_mime_words(email_message["To"]),
+                                            "date": email_message["Date"],
+                                            "body": self.get_email_body(email_message),
                                         }
                 except Exception as e:
-                    logger.warning(f"Failed to fetch batch {i//batch_size + 1}: {e}")
+                    logger.warning(f"Failed to fetch batch {i // batch_size + 1}: {e}")
                     # Fallback to individual fetching for this batch
                     for email_id in batch_ids:
                         try:
-                            status, msg_data = mail.fetch(email_id, '(RFC822)')
-                            if status == 'OK' and msg_data and msg_data[0][1]:
+                            status, msg_data = mail.fetch(email_id, "(RFC822)")
+                            if status == "OK" and msg_data and msg_data[0][1]:
                                 raw_email = msg_data[0][1]
                                 email_message = email.message_from_bytes(raw_email)
                                 emails[email_id] = {
-                                    'id': email_id,
-                                    'subject': self.decode_mime_words(email_message['Subject']),
-                                    'from': self.decode_mime_words(email_message['From']),
-                                    'to': self.decode_mime_words(email_message['To']),
-                                    'date': email_message['Date'],
-                                    'body': self.get_email_body(email_message)
+                                    "id": email_id,
+                                    "subject": self.decode_mime_words(email_message["Subject"]),
+                                    "from": self.decode_mime_words(email_message["From"]),
+                                    "to": self.decode_mime_words(email_message["To"]),
+                                    "date": email_message["Date"],
+                                    "body": self.get_email_body(email_message),
                                 }
                         except Exception as inner_e:
                             logger.warning(f"Failed to fetch email {email_id}: {inner_e}")
                             continue
-        
+
         finally:
             if mailbox_selected:
                 mail.close()
             mail.logout()
-        
+
         return emails
-    
-    def get_bulk_emails_with_html(self, email_ids: List[str], mailbox: str = "INBOX", batch_size: int = 30):
+
+    def get_bulk_emails_with_html(self, email_ids: list[str], mailbox: str = "INBOX", batch_size: int = 30):
         """
         Get multiple emails with HTML content efficiently in batches.
         Used for unsubscribe link detection and other HTML analysis.
         """
         if not email_ids:
             return {}
-        
+
         mail = self.connect_imap()
         emails = {}
         mailbox_selected = False
-        
+
         try:
             status, response = mail.select(mailbox)
-            if status != 'OK':
+            if status != "OK":
                 logger.error(f"Failed to select mailbox '{mailbox}': {response}")
                 return {}
             mailbox_selected = True
-            
+
             # Process in smaller batches since HTML emails are larger
             for i in range(0, len(email_ids), batch_size):
-                batch_ids = email_ids[i:i + batch_size]
-                id_list = ','.join(batch_ids)
-                
+                batch_ids = email_ids[i : i + batch_size]
+                id_list = ",".join(batch_ids)
+
                 try:
-                    status, msg_data = mail.fetch(id_list, '(RFC822)')
-                    
-                    if status == 'OK' and msg_data:
+                    status, msg_data = mail.fetch(id_list, "(RFC822)")
+
+                    if status == "OK" and msg_data:
                         for item in msg_data:
                             if isinstance(item, tuple) and len(item) >= 2:
                                 # Parse sequence number from IMAP response header
                                 # Format: b'123 (RFC822 {size}' or b'123 (BODY[] {size}'
                                 header = item[0]
                                 if isinstance(header, bytes):
-                                    seq_num = header.split()[0].decode('ascii', errors='ignore')
+                                    seq_num = header.split()[0].decode("ascii", errors="ignore")
                                     raw_email = item[1]
                                     if raw_email:
                                         email_message = email.message_from_bytes(raw_email)
-                                    
+
                                         # Extract both text and HTML content
                                         text_content = ""
                                         html_content = ""
-                                    
+
                                         if email_message.is_multipart():
                                             for part in email_message.walk():
                                                 content_type = part.get_content_type()
@@ -336,7 +338,7 @@ class ProtonEmailClient:
                                                     try:
                                                         payload = part.get_payload(decode=True)
                                                         if payload:
-                                                            content = payload.decode('utf-8', errors='ignore')
+                                                            content = payload.decode("utf-8", errors="ignore")
                                                             if content_type == "text/plain":
                                                                 text_content += content
                                                             elif content_type == "text/html":
@@ -347,7 +349,7 @@ class ProtonEmailClient:
                                             try:
                                                 payload = email_message.get_payload(decode=True)
                                                 if payload:
-                                                    content = payload.decode('utf-8', errors='ignore')
+                                                    content = payload.decode("utf-8", errors="ignore")
                                                     if email_message.get_content_type() == "text/html":
                                                         html_content = content
                                                     else:
@@ -356,47 +358,47 @@ class ProtonEmailClient:
                                                 pass
 
                                         emails[seq_num] = {
-                                            'id': seq_num,
-                                            'subject': self.decode_mime_words(email_message['Subject']),
-                                            'from': self.decode_mime_words(email_message['From']),
-                                            'to': self.decode_mime_words(email_message['To']),
-                                            'date': email_message['Date'],
-                                            'text_body': text_content,
-                                            'html_body': html_content,
-                                            'list_unsubscribe': email_message.get('List-Unsubscribe', ''),
-                                            'list_unsubscribe_post': email_message.get('List-Unsubscribe-Post', '')
+                                            "id": seq_num,
+                                            "subject": self.decode_mime_words(email_message["Subject"]),
+                                            "from": self.decode_mime_words(email_message["From"]),
+                                            "to": self.decode_mime_words(email_message["To"]),
+                                            "date": email_message["Date"],
+                                            "text_body": text_content,
+                                            "html_body": html_content,
+                                            "list_unsubscribe": email_message.get("List-Unsubscribe", ""),
+                                            "list_unsubscribe_post": email_message.get("List-Unsubscribe-Post", ""),
                                         }
                 except Exception as e:
-                    logger.warning(f"Failed to fetch HTML batch {i//batch_size + 1}: {e}")
+                    logger.warning(f"Failed to fetch HTML batch {i // batch_size + 1}: {e}")
                     # Fallback to individual fetching
                     for email_id in batch_ids:
                         individual_result = self.get_full_email_with_html(email_id, mailbox)
                         if individual_result:
                             emails[email_id] = individual_result
-        
+
         finally:
             if mailbox_selected:
                 mail.close()
             mail.logout()
-        
+
         return emails
-    
+
     def send_email(self, to: str, subject: str, body: str, reply_to_id: str = None):
         """Send email via SMTP"""
         server = self.connect_smtp()
         try:
             msg = MIMEMultipart()
-            msg['From'] = self.email
-            msg['To'] = to
-            msg['Subject'] = subject
-            
+            msg["From"] = self.email
+            msg["To"] = to
+            msg["Subject"] = subject
+
             # Add reply headers if replying to an email
             if reply_to_id:
-                msg['In-Reply-To'] = reply_to_id
-                msg['References'] = reply_to_id
-            
-            msg.attach(MIMEText(body, 'plain'))
-            
+                msg["In-Reply-To"] = reply_to_id
+                msg["References"] = reply_to_id
+
+            msg.attach(MIMEText(body, "plain"))
+
             server.send_message(msg)
             return True
         except Exception as e:
@@ -404,86 +406,86 @@ class ProtonEmailClient:
             return False
         finally:
             server.quit()
-    
-    def is_junk_email(self, email_data: Dict) -> Dict[str, Any]:
+
+    def is_junk_email(self, email_data: dict) -> dict[str, Any]:
         """
         Analyze email to determine if it's likely junk/spam.
         Returns a dictionary with junk detection results.
         """
         junk_indicators = []
         junk_score = 0
-        
-        subject = email_data.get('subject', '').lower()
-        from_addr = email_data.get('from', '').lower()
-        body = email_data.get('body', '').lower()
-        
+
+        subject = email_data.get("subject", "").lower()
+        from_addr = email_data.get("from", "").lower()
+        body = email_data.get("body", "").lower()
+
         # Common spam subject patterns
         spam_subject_patterns = [
-            r'urgent.*action.*required',
-            r'congratulations.*won',
-            r'free.*money|money.*free',
-            r'limited.*time.*offer',
-            r'act.*now|click.*here',
-            r'viagra|cialis|pharmacy',
-            r'increase.*size',
-            r'lose.*weight.*fast',
-            r'make.*money.*fast',
-            r'nigerian.*prince',
-            r'tax.*refund',
-            r'security.*alert',
-            r're:.*re:.*re:',  # Multiple "re:" forwards
+            r"urgent.*action.*required",
+            r"congratulations.*won",
+            r"free.*money|money.*free",
+            r"limited.*time.*offer",
+            r"act.*now|click.*here",
+            r"viagra|cialis|pharmacy",
+            r"increase.*size",
+            r"lose.*weight.*fast",
+            r"make.*money.*fast",
+            r"nigerian.*prince",
+            r"tax.*refund",
+            r"security.*alert",
+            r"re:.*re:.*re:",  # Multiple "re:" forwards
         ]
-        
+
         for pattern in spam_subject_patterns:
             if re.search(pattern, subject):
                 junk_indicators.append(f"Suspicious subject pattern: {pattern}")
                 junk_score += 2
-        
+
         # Check for suspicious sender patterns
         suspicious_sender_patterns = [
-            r'noreply@.*\.tk$',  # Suspicious TLDs
-            r'.*@.*\.ml$',
-            r'.*@.*\.ga$',
-            r'admin@.*',
-            r'support@.*',
-            r'security@.*',
+            r"noreply@.*\.tk$",  # Suspicious TLDs
+            r".*@.*\.ml$",
+            r".*@.*\.ga$",
+            r"admin@.*",
+            r"support@.*",
+            r"security@.*",
         ]
-        
+
         for pattern in suspicious_sender_patterns:
             if re.search(pattern, from_addr):
                 junk_indicators.append(f"Suspicious sender pattern: {pattern}")
                 junk_score += 1
-        
+
         # Check body content for spam indicators
         spam_body_patterns = [
-            r'click.*here.*now',
-            r'urgent.*respond',
-            r'verify.*account.*immediately',
-            r'suspended.*account',
-            r'winner.*lottery',
-            r'inheritance.*million',
-            r'bitcoin.*investment',
-            r'crypto.*opportunity',
+            r"click.*here.*now",
+            r"urgent.*respond",
+            r"verify.*account.*immediately",
+            r"suspended.*account",
+            r"winner.*lottery",
+            r"inheritance.*million",
+            r"bitcoin.*investment",
+            r"crypto.*opportunity",
         ]
-        
+
         for pattern in spam_body_patterns:
             if re.search(pattern, body):
                 junk_indicators.append(f"Suspicious body content: {pattern}")
                 junk_score += 2
-        
+
         # Check for excessive caps
         if len(subject) > 10:
             caps_ratio = sum(1 for c in subject if c.isupper()) / len(subject)
             if caps_ratio > 0.5:
                 junk_indicators.append("Excessive capital letters in subject")
                 junk_score += 1
-        
+
         # Check for excessive exclamation marks
-        exclamation_count = subject.count('!') + body[:500].count('!')
+        exclamation_count = subject.count("!") + body[:500].count("!")
         if exclamation_count > 3:
             junk_indicators.append(f"Excessive exclamation marks ({exclamation_count})")
             junk_score += 1
-        
+
         # Determine junk likelihood
         if junk_score >= 4:
             likelihood = "high"
@@ -493,31 +495,31 @@ class ProtonEmailClient:
             likelihood = "low"
         else:
             likelihood = "unlikely"
-        
+
         return {
             "is_likely_junk": junk_score >= 2,
             "junk_score": junk_score,
             "likelihood": likelihood,
             "indicators": junk_indicators,
-            "email_id": email_data.get('id')
+            "email_id": email_data.get("id"),
         }
-    
+
     def move_email_to_folder(self, email_id: str, target_folder: str, source_folder: str = "INBOX"):
         """Move an email from one folder to another"""
         mail = self.connect_imap()
         mailbox_selected = False
         try:
             status, response = mail.select(source_folder)
-            if status != 'OK':
+            if status != "OK":
                 logger.error(f"Failed to select source folder '{source_folder}': {response}")
                 return False
             mailbox_selected = True
-            
+
             # Copy email to target folder
             result = mail.copy(email_id, target_folder)
-            if result[0] == 'OK':
+            if result[0] == "OK":
                 # Mark as deleted in source folder
-                mail.store(email_id, '+FLAGS', '\\Deleted')
+                mail.store(email_id, "+FLAGS", "\\Deleted")
                 mail.expunge()
                 return True
             else:
@@ -530,57 +532,63 @@ class ProtonEmailClient:
             if mailbox_selected:
                 mail.close()
             mail.logout()
-    
-    def bulk_move_emails(self, email_ids: List[str], target_folder: str, source_folder: str = "INBOX", batch_size: int = 100):
+
+    def bulk_move_emails(
+        self, email_ids: list[str], target_folder: str, source_folder: str = "INBOX", batch_size: int = 100
+    ):
         """
         Move multiple emails to a folder efficiently using batch operations.
-        
+
         Args:
             email_ids: List of email IDs to move
             target_folder: Destination folder
             source_folder: Source folder (default: INBOX)
             batch_size: Number of emails to process per batch
-        
+
         Returns:
             Dictionary with success/failure counts and details
         """
         if not email_ids:
-            return {'moved': 0, 'failed': 0, 'details': []}
-        
+            return {"moved": 0, "failed": 0, "details": []}
+
         mail = self.connect_imap()
         moved_count = 0
         failed_count = 0
         details = []
         mailbox_selected = False
-        
+
         try:
             status, response = mail.select(source_folder)
-            if status != 'OK':
+            if status != "OK":
                 logger.error(f"Failed to select source folder '{source_folder}': {response}")
-                return {'moved': 0, 'failed': len(email_ids), 'error': f'Failed to select source folder: {source_folder}'}
+                return {
+                    "moved": 0,
+                    "failed": len(email_ids),
+                    "error": f"Failed to select source folder: {source_folder}",
+                }
             mailbox_selected = True
-            
+
             # Process emails in batches for efficiency
             for i in range(0, len(email_ids), batch_size):
-                batch_ids = email_ids[i:i + batch_size]
-                id_list = ','.join(batch_ids)
-                
+                batch_ids = email_ids[i : i + batch_size]
+                id_list = ",".join(batch_ids)
+
                 try:
                     # Bulk copy operation
                     result = mail.copy(id_list, target_folder)
-                    
-                    if result[0] == 'OK':
+
+                    if result[0] == "OK":
                         # Bulk mark as deleted
-                        mail.store(id_list, '+FLAGS', '\\Deleted')
+                        mail.store(id_list, "+FLAGS", "\\Deleted")
                         moved_count += len(batch_ids)
-                        details.append(f"Successfully moved batch {i//batch_size + 1}: {len(batch_ids)} emails")
+                        details.append(f"Successfully moved batch {i // batch_size + 1}: {len(batch_ids)} emails")
                     else:
                         # If batch fails, try individual moves
                         for email_id in batch_ids:
                             try:
                                 individual_result = mail.copy(email_id, target_folder)
-                                if individual_result[0] == 'OK':
-                                    mail.store(email_id, '+FLAGS', '\\Deleted')
+                                if individual_result[0] == "OK":
+                                    mail.store(email_id, "+FLAGS", "\\Deleted")
                                     moved_count += 1
                                 else:
                                     failed_count += 1
@@ -588,138 +596,140 @@ class ProtonEmailClient:
                             except Exception as e:
                                 failed_count += 1
                                 details.append(f"Error moving email {email_id}: {str(e)}")
-                
+
                 except Exception as e:
-                    logger.warning(f"Failed to move batch {i//batch_size + 1}: {e}")
+                    logger.warning(f"Failed to move batch {i // batch_size + 1}: {e}")
                     # Fallback to individual moves for this batch
                     for email_id in batch_ids:
                         try:
                             result = mail.copy(email_id, target_folder)
-                            if result[0] == 'OK':
-                                mail.store(email_id, '+FLAGS', '\\Deleted')
+                            if result[0] == "OK":
+                                mail.store(email_id, "+FLAGS", "\\Deleted")
                                 moved_count += 1
                             else:
                                 failed_count += 1
                         except Exception as inner_e:
                             failed_count += 1
                             details.append(f"Error moving email {email_id}: {str(inner_e)}")
-            
+
             # Expunge all deleted emails at once
             if moved_count > 0:
                 mail.expunge()
-                
+
         except Exception as e:
             logger.error(f"Bulk move operation failed: {e}")
-            return {'moved': 0, 'failed': len(email_ids), 'error': str(e)}
+            return {"moved": 0, "failed": len(email_ids), "error": str(e)}
         finally:
             if mailbox_selected:
                 mail.close()
             mail.logout()
-        
+
         return {
-            'moved': moved_count,
-            'failed': failed_count,
-            'total': len(email_ids),
-            'details': details[:10]  # Limit details to first 10 for readability
+            "moved": moved_count,
+            "failed": failed_count,
+            "total": len(email_ids),
+            "details": details[:10],  # Limit details to first 10 for readability
         }
-    
-    def bulk_mark_emails(self, email_ids: List[str], flag: str, action: str = "add", mailbox: str = "INBOX", batch_size: int = 100):
+
+    def bulk_mark_emails(
+        self, email_ids: list[str], flag: str, action: str = "add", mailbox: str = "INBOX", batch_size: int = 100
+    ):
         """
         Bulk mark emails with IMAP flags (read, important, etc.).
-        
+
         Args:
             email_ids: List of email IDs to mark
             flag: IMAP flag to set (e.g., '\\Seen', '\\Flagged', '\\Deleted')
             action: 'add' to set flag, 'remove' to unset flag
             mailbox: Mailbox containing the emails
             batch_size: Number of emails to process per batch
-        
+
         Returns:
             Dictionary with success/failure counts
         """
         if not email_ids:
-            return {'marked': 0, 'failed': 0}
-        
+            return {"marked": 0, "failed": 0}
+
         mail = self.connect_imap()
         marked_count = 0
         failed_count = 0
         mailbox_selected = False
-        
+
         try:
             status, response = mail.select(mailbox)
-            if status != 'OK':
+            if status != "OK":
                 logger.error(f"Failed to select mailbox '{mailbox}': {response}")
-                return {'marked': 0, 'failed': len(email_ids), 'error': f'Failed to select mailbox: {mailbox}'}
+                return {"marked": 0, "failed": len(email_ids), "error": f"Failed to select mailbox: {mailbox}"}
             mailbox_selected = True
-            
-            flag_action = '+FLAGS' if action == 'add' else '-FLAGS'
-            
+
+            flag_action = "+FLAGS" if action == "add" else "-FLAGS"
+
             # Process in batches
             for i in range(0, len(email_ids), batch_size):
-                batch_ids = email_ids[i:i + batch_size]
-                id_list = ','.join(batch_ids)
-                
+                batch_ids = email_ids[i : i + batch_size]
+                id_list = ",".join(batch_ids)
+
                 try:
                     result = mail.store(id_list, flag_action, flag)
-                    if result[0] == 'OK':
+                    if result[0] == "OK":
                         marked_count += len(batch_ids)
                     else:
                         # Fallback to individual marking
                         for email_id in batch_ids:
                             try:
                                 individual_result = mail.store(email_id, flag_action, flag)
-                                if individual_result[0] == 'OK':
+                                if individual_result[0] == "OK":
                                     marked_count += 1
                                 else:
                                     failed_count += 1
                             except Exception:
                                 failed_count += 1
-                
+
                 except Exception as e:
-                    logger.warning(f"Failed to mark batch {i//batch_size + 1}: {e}")
+                    logger.warning(f"Failed to mark batch {i // batch_size + 1}: {e}")
                     # Fallback to individual marking
                     for email_id in batch_ids:
                         try:
                             result = mail.store(email_id, flag_action, flag)
-                            if result[0] == 'OK':
+                            if result[0] == "OK":
                                 marked_count += 1
                             else:
                                 failed_count += 1
                         except Exception:
                             failed_count += 1
-        
+
         except Exception as e:
             logger.error(f"Bulk mark operation failed: {e}")
-            return {'marked': 0, 'failed': len(email_ids), 'error': str(e)}
+            return {"marked": 0, "failed": len(email_ids), "error": str(e)}
         finally:
             if mailbox_selected:
                 mail.close()
             mail.logout()
-        
-        return {'marked': marked_count, 'failed': failed_count, 'total': len(email_ids)}
-    
-    def bulk_delete_emails(self, email_ids: List[str], mailbox: str = "INBOX", permanent: bool = False):
+
+        return {"marked": marked_count, "failed": failed_count, "total": len(email_ids)}
+
+    def bulk_delete_emails(self, email_ids: list[str], mailbox: str = "INBOX", permanent: bool = False):
         """
         Bulk delete emails (move to Trash or permanent deletion).
-        
+
         Args:
             email_ids: List of email IDs to delete
             mailbox: Source mailbox
             permanent: If True, permanently delete; if False, move to Trash
-        
+
         Returns:
             Dictionary with deletion results
         """
         if permanent:
             # Permanent deletion using bulk marking and expunge
-            result = self.bulk_mark_emails(email_ids, '\\Deleted', 'add', mailbox)
-            if result['marked'] > 0:
+            result = self.bulk_mark_emails(email_ids, "\\Deleted", "add", mailbox)
+            if result["marked"] > 0:
                 # Expunge to permanently delete
                 mail = self.connect_imap()
                 mailbox_selected = False
                 try:
                     status, response = mail.select(mailbox)
-                    if status == 'OK':
+                    if status == "OK":
                         mailbox_selected = True
                         mail.expunge()
                     else:
@@ -728,17 +738,17 @@ class ProtonEmailClient:
                     if mailbox_selected:
                         mail.close()
                     mail.logout()
-            return {'deleted': result['marked'], 'failed': result['failed'], 'permanent': True}
+            return {"deleted": result["marked"], "failed": result["failed"], "permanent": True}
         else:
             # Move to Trash folder
-            return self.bulk_move_emails(email_ids, 'Trash', mailbox)
-    
+            return self.bulk_move_emails(email_ids, "Trash", mailbox)
+
     def get_mailbox_list(self):
         """Get list of available mailboxes/folders"""
         mail = self.connect_imap()
         try:
             status, mailboxes = mail.list()
-            if status == 'OK':
+            if status == "OK":
                 folder_list = []
                 for mailbox in mailboxes:
                     # Parse mailbox name from IMAP response
@@ -753,13 +763,13 @@ class ProtonEmailClient:
             return []
         finally:
             mail.logout()
-    
+
     def create_folder(self, folder_name: str):
         """Create a new folder/mailbox"""
         mail = self.connect_imap()
         try:
             status, response = mail.create(folder_name)
-            if status == 'OK':
+            if status == "OK":
                 logger.info(f"Successfully created folder: {folder_name}")
                 return True
             else:
@@ -770,13 +780,13 @@ class ProtonEmailClient:
             return False
         finally:
             mail.logout()
-    
+
     def delete_folder(self, folder_name: str):
         """Delete an existing folder/mailbox"""
         mail = self.connect_imap()
         try:
             status, response = mail.delete(folder_name)
-            if status == 'OK':
+            if status == "OK":
                 logger.info(f"Successfully deleted folder: {folder_name}")
                 return True
             else:
@@ -787,434 +797,439 @@ class ProtonEmailClient:
             return False
         finally:
             mail.logout()
-    
-    def load_filter_rules(self) -> List[Dict]:
+
+    def load_filter_rules(self) -> list[dict]:
         """Load filtering rules from JSON file"""
         try:
             if os.path.exists(self.rules_file):
-                with open(self.rules_file, 'r') as f:
+                with open(self.rules_file) as f:
                     return json.load(f)
             return []
         except Exception as e:
             logger.error(f"Failed to load filter rules: {e}")
             return []
-    
-    def save_filter_rules(self, rules: List[Dict]) -> bool:
+
+    def save_filter_rules(self, rules: list[dict]) -> bool:
         """Save filtering rules to JSON file"""
         try:
-            with open(self.rules_file, 'w') as f:
+            with open(self.rules_file, "w") as f:
                 json.dump(rules, f, indent=2)
             return True
         except Exception as e:
             logger.error(f"Failed to save filter rules: {e}")
             return False
-    
-    def create_filter_rule(self, rule_name: str, conditions: Dict, actions: Dict, enabled: bool = True) -> bool:
+
+    def create_filter_rule(self, rule_name: str, conditions: dict, actions: dict, enabled: bool = True) -> bool:
         """
         Create a new email filtering rule.
-        
+
         Args:
             rule_name: Unique name for the rule
             conditions: Dictionary of conditions to match (e.g., {'from': 'sender@example.com', 'subject_contains': 'newsletter'})
             actions: Dictionary of actions to take (e.g., {'move_to_folder': 'Newsletter', 'mark_as_read': True})
             enabled: Whether the rule is active
-        
+
         Returns:
             True if rule was created successfully
         """
         rules = self.load_filter_rules()
-        
+
         # Check if rule name already exists
-        if any(rule['name'] == rule_name for rule in rules):
+        if any(rule["name"] == rule_name for rule in rules):
             logger.error(f"Rule with name '{rule_name}' already exists")
             return False
-        
+
         # Validate conditions
         valid_conditions = [
-            'from', 'to', 'subject_contains', 'subject_equals', 'body_contains',
-            'sender_domain', 'has_attachments', 'older_than_days', 'newer_than_days'
+            "from",
+            "to",
+            "subject_contains",
+            "subject_equals",
+            "body_contains",
+            "sender_domain",
+            "has_attachments",
+            "older_than_days",
+            "newer_than_days",
         ]
         for condition in conditions.keys():
             if condition not in valid_conditions:
                 logger.error(f"Invalid condition: {condition}")
                 return False
-        
+
         # Validate actions
-        valid_actions = [
-            'move_to_folder', 'mark_as_read', 'mark_as_important', 'delete',
-            'forward_to', 'auto_reply'
-        ]
+        valid_actions = ["move_to_folder", "mark_as_read", "mark_as_important", "delete", "forward_to", "auto_reply"]
         for action in actions.keys():
             if action not in valid_actions:
                 logger.error(f"Invalid action: {action}")
                 return False
-        
+
         # Create new rule
         new_rule = {
-            'id': str(uuid.uuid4()),
-            'name': rule_name,
-            'conditions': conditions,
-            'actions': actions,
-            'enabled': enabled,
-            'created_at': datetime.now().isoformat(),
-            'last_applied': None,
-            'emails_processed': 0
+            "id": str(uuid.uuid4()),
+            "name": rule_name,
+            "conditions": conditions,
+            "actions": actions,
+            "enabled": enabled,
+            "created_at": datetime.now().isoformat(),
+            "last_applied": None,
+            "emails_processed": 0,
         }
-        
+
         rules.append(new_rule)
         return self.save_filter_rules(rules)
-    
+
     def delete_filter_rule(self, rule_id: str) -> bool:
         """Delete a filtering rule by ID"""
         rules = self.load_filter_rules()
-        updated_rules = [rule for rule in rules if rule['id'] != rule_id]
-        
+        updated_rules = [rule for rule in rules if rule["id"] != rule_id]
+
         if len(updated_rules) == len(rules):
             logger.error(f"Rule with ID '{rule_id}' not found")
             return False
-        
+
         return self.save_filter_rules(updated_rules)
-    
+
     def update_filter_rule(self, rule_id: str, **updates) -> bool:
         """Update an existing filtering rule"""
         rules = self.load_filter_rules()
-        
+
         for rule in rules:
-            if rule['id'] == rule_id:
+            if rule["id"] == rule_id:
                 rule.update(updates)
                 return self.save_filter_rules(rules)
-        
+
         logger.error(f"Rule with ID '{rule_id}' not found")
         return False
-    
-    def email_matches_rule(self, email_data: Dict, rule: Dict) -> bool:
+
+    def email_matches_rule(self, email_data: dict, rule: dict) -> bool:
         """Check if an email matches a filtering rule's conditions"""
-        conditions = rule.get('conditions', {})
+        conditions = rule.get("conditions", {})
         matches = True
 
         for condition, value in conditions.items():
-            if condition == 'from':
-                if value.lower() not in email_data.get('from', '').lower():
+            if condition == "from":
+                if value.lower() not in email_data.get("from", "").lower():
                     return False
-            elif condition == 'to':
-                if value.lower() not in email_data.get('to', '').lower():
+            elif condition == "to":
+                if value.lower() not in email_data.get("to", "").lower():
                     return False
-            elif condition == 'subject_contains':
-                if value.lower() not in email_data.get('subject', '').lower():
+            elif condition == "subject_contains":
+                if value.lower() not in email_data.get("subject", "").lower():
                     return False
-            elif condition == 'subject_equals':
-                if value.lower() != email_data.get('subject', '').lower():
+            elif condition == "subject_equals":
+                if value.lower() != email_data.get("subject", "").lower():
                     return False
-            elif condition == 'body_contains':
-                if value.lower() not in email_data.get('body', '').lower():
+            elif condition == "body_contains":
+                if value.lower() not in email_data.get("body", "").lower():
                     return False
-            elif condition == 'sender_domain':
-                sender = email_data.get('from', '')
-                domain = sender.split('@')[-1] if '@' in sender else ''
+            elif condition == "sender_domain":
+                sender = email_data.get("from", "")
+                domain = sender.split("@")[-1] if "@" in sender else ""
                 if value.lower() != domain.lower():
                     return False
-            elif condition == 'has_attachments':
+            elif condition == "has_attachments":
                 # This would need to be implemented based on email structure
                 logger.warning(f"Condition '{condition}' is not yet implemented, skipping email")
                 matches = False
                 break
-            elif condition == 'older_than_days' or condition == 'newer_than_days':
+            elif condition == "older_than_days" or condition == "newer_than_days":
                 # This would need date parsing and comparison
                 logger.warning(f"Condition '{condition}' is not yet implemented, skipping email")
                 matches = False
                 break
 
         return matches
-    
-    def apply_rule_actions(self, email_id: str, rule: Dict, mailbox: str = "INBOX") -> Dict[str, Any]:
+
+    def apply_rule_actions(self, email_id: str, rule: dict, mailbox: str = "INBOX") -> dict[str, Any]:
         """Apply the actions specified in a filtering rule to an email"""
-        actions = rule.get('actions', {})
+        actions = rule.get("actions", {})
         results = {}
-        
+
         for action, value in actions.items():
             try:
-                if action == 'move_to_folder':
+                if action == "move_to_folder":
                     success = self.move_email_to_folder(email_id, value, mailbox)
-                    results[action] = {'success': success, 'target_folder': value}
-                elif action == 'mark_as_read':
+                    results[action] = {"success": success, "target_folder": value}
+                elif action == "mark_as_read":
                     if value:  # Only if True
                         # Implementation would require IMAP STORE command
-                        results[action] = {'success': False, 'message': 'Not implemented for individual emails; use bulk operations'}
-                elif action == 'delete':
+                        results[action] = {
+                            "success": False,
+                            "message": "Not implemented for individual emails; use bulk operations",
+                        }
+                elif action == "delete":
                     if value:  # Only if True
-                        success = self.move_email_to_folder(email_id, 'Trash', mailbox)
-                        results[action] = {'success': success}
-                elif action == 'mark_as_important':
+                        success = self.move_email_to_folder(email_id, "Trash", mailbox)
+                        results[action] = {"success": success}
+                elif action == "mark_as_important":
                     if value:  # Only if True
                         # Implementation would require IMAP flag setting
-                        results[action] = {'success': False, 'message': 'Not implemented for individual emails; use bulk operations'}
+                        results[action] = {
+                            "success": False,
+                            "message": "Not implemented for individual emails; use bulk operations",
+                        }
                 # Forward and auto-reply would be more complex implementations
             except Exception as e:
-                results[action] = {'success': False, 'error': str(e)}
-        
+                results[action] = {"success": False, "error": str(e)}
+
         return results
-    
-    def apply_filter_rules(self, mailbox: str = "INBOX", limit: int = 50) -> Dict[str, Any]:
+
+    def apply_filter_rules(self, mailbox: str = "INBOX", limit: int = 50) -> dict[str, Any]:
         """Apply all enabled filtering rules to emails in a mailbox using bulk operations"""
         rules = self.load_filter_rules()
-        enabled_rules = [rule for rule in rules if rule.get('enabled', True)]
-        
+        enabled_rules = [rule for rule in rules if rule.get("enabled", True)]
+
         if not enabled_rules:
-            return {'message': 'No enabled rules found', 'emails_processed': 0, 'actions_taken': 0}
-        
+            return {"message": "No enabled rules found", "emails_processed": 0, "actions_taken": 0}
+
         # Get recent emails
         emails = self.search_emails("ALL", mailbox, limit)
         if not emails or (len(emails) == 1 and "error" in emails[0]):
-            return {'error': 'Failed to retrieve emails'}
-        
+            return {"error": "Failed to retrieve emails"}
+
         # Extract email IDs for bulk retrieval
-        email_ids = [email['id'] for email in emails]
-        
+        email_ids = [email["id"] for email in emails]
+
         # Bulk retrieve full email content
         logger.info(f"Bulk retrieving {len(email_ids)} emails for rule processing")
         full_emails = self.get_bulk_emails(email_ids, mailbox)
-        
+
         if not full_emails:
-            return {'error': 'Failed to retrieve email content'}
-        
+            return {"error": "Failed to retrieve email content"}
+
         # Group actions by type for bulk execution
         bulk_actions = {
-            'move_to_folder': {},  # {target_folder: [email_ids]}
-            'mark_as_read': [],
-            'mark_as_important': [],
-            'delete': []
+            "move_to_folder": {},  # {target_folder: [email_ids]}
+            "mark_as_read": [],
+            "mark_as_important": [],
+            "delete": [],
         }
-        
+
         processed_count = 0
         rule_results = []
-        
+
         # Process each email against all rules
         for email_id, full_email in full_emails.items():
             processed_count += 1
-            
+
             for rule in enabled_rules:
                 if self.email_matches_rule(full_email, rule):
-                    actions = rule.get('actions', {})
-                    
+                    actions = rule.get("actions", {})
+
                     # Queue actions for bulk execution instead of executing individually
                     for action, value in actions.items():
-                        if action == 'move_to_folder' and value:
-                            if value not in bulk_actions['move_to_folder']:
-                                bulk_actions['move_to_folder'][value] = []
-                            bulk_actions['move_to_folder'][value].append(email_id)
-                        elif action == 'mark_as_read' and value:
-                            bulk_actions['mark_as_read'].append(email_id)
-                        elif action == 'mark_as_important' and value:
-                            bulk_actions['mark_as_important'].append(email_id)
-                        elif action == 'delete' and value:
-                            bulk_actions['delete'].append(email_id)
-                    
+                        if action == "move_to_folder" and value:
+                            if value not in bulk_actions["move_to_folder"]:
+                                bulk_actions["move_to_folder"][value] = []
+                            bulk_actions["move_to_folder"][value].append(email_id)
+                        elif action == "mark_as_read" and value:
+                            bulk_actions["mark_as_read"].append(email_id)
+                        elif action == "mark_as_important" and value:
+                            bulk_actions["mark_as_important"].append(email_id)
+                        elif action == "delete" and value:
+                            bulk_actions["delete"].append(email_id)
+
                     rule_result = {
-                        'rule_id': rule['id'],
-                        'rule_name': rule['name'],
-                        'email_id': email_id,
-                        'email_subject': full_email.get('subject', ''),
-                        'actions_queued': list(actions.keys())
+                        "rule_id": rule["id"],
+                        "rule_name": rule["name"],
+                        "email_id": email_id,
+                        "email_subject": full_email.get("subject", ""),
+                        "actions_queued": list(actions.keys()),
                     }
                     rule_results.append(rule_result)
-                    
+
                     # Update rule statistics
-                    rule['emails_processed'] = rule.get('emails_processed', 0) + 1
-                    rule['last_applied'] = datetime.now().isoformat()
-        
+                    rule["emails_processed"] = rule.get("emails_processed", 0) + 1
+                    rule["last_applied"] = datetime.now().isoformat()
+
         # Execute bulk actions
         actions_taken = 0
         bulk_results = {}
-        
+
         # Bulk move operations
-        for target_folder, email_ids_to_move in bulk_actions['move_to_folder'].items():
+        for target_folder, email_ids_to_move in bulk_actions["move_to_folder"].items():
             if email_ids_to_move:
                 logger.info(f"Bulk moving {len(email_ids_to_move)} emails to {target_folder}")
                 move_result = self.bulk_move_emails(email_ids_to_move, target_folder, mailbox)
-                bulk_results[f'move_to_{target_folder}'] = move_result
-                actions_taken += move_result.get('moved', 0)
-        
+                bulk_results[f"move_to_{target_folder}"] = move_result
+                actions_taken += move_result.get("moved", 0)
+
         # Bulk mark as read
-        if bulk_actions['mark_as_read']:
+        if bulk_actions["mark_as_read"]:
             logger.info(f"Bulk marking {len(bulk_actions['mark_as_read'])} emails as read")
-            read_result = self.bulk_mark_emails(bulk_actions['mark_as_read'], '\\Seen', 'add', mailbox)
-            bulk_results['mark_as_read'] = read_result
-            actions_taken += read_result.get('marked', 0)
-        
+            read_result = self.bulk_mark_emails(bulk_actions["mark_as_read"], "\\Seen", "add", mailbox)
+            bulk_results["mark_as_read"] = read_result
+            actions_taken += read_result.get("marked", 0)
+
         # Bulk mark as important
-        if bulk_actions['mark_as_important']:
+        if bulk_actions["mark_as_important"]:
             logger.info(f"Bulk marking {len(bulk_actions['mark_as_important'])} emails as important")
-            important_result = self.bulk_mark_emails(bulk_actions['mark_as_important'], '\\Flagged', 'add', mailbox)
-            bulk_results['mark_as_important'] = important_result
-            actions_taken += important_result.get('marked', 0)
-        
+            important_result = self.bulk_mark_emails(bulk_actions["mark_as_important"], "\\Flagged", "add", mailbox)
+            bulk_results["mark_as_important"] = important_result
+            actions_taken += important_result.get("marked", 0)
+
         # Bulk delete
-        if bulk_actions['delete']:
+        if bulk_actions["delete"]:
             logger.info(f"Bulk deleting {len(bulk_actions['delete'])} emails")
-            delete_result = self.bulk_delete_emails(bulk_actions['delete'], mailbox, permanent=False)
-            bulk_results['delete'] = delete_result
-            actions_taken += delete_result.get('deleted', 0)
-        
+            delete_result = self.bulk_delete_emails(bulk_actions["delete"], mailbox, permanent=False)
+            bulk_results["delete"] = delete_result
+            actions_taken += delete_result.get("deleted", 0)
+
         # Save updated rule statistics
         self.save_filter_rules(rules)
-        
+
         return {
-            'emails_processed': processed_count,
-            'rules_applied': len(rule_results),
-            'actions_taken': actions_taken,
-            'bulk_results': bulk_results,
-            'rule_results': rule_results[:20]  # Limit detailed results for readability
+            "emails_processed": processed_count,
+            "rules_applied": len(rule_results),
+            "actions_taken": actions_taken,
+            "bulk_results": bulk_results,
+            "rule_results": rule_results[:20],  # Limit detailed results for readability
         }
-    
-    def apply_filter_rules_optimized(self, mailbox: str = "INBOX", limit: int = 200, chunk_size: int = 50) -> Dict[str, Any]:
+
+    def apply_filter_rules_optimized(
+        self, mailbox: str = "INBOX", limit: int = 200, chunk_size: int = 50
+    ) -> dict[str, Any]:
         """
         Highly optimized filter rule application for large email volumes.
         Processes emails in chunks to manage memory usage.
         """
         rules = self.load_filter_rules()
-        enabled_rules = [rule for rule in rules if rule.get('enabled', True)]
-        
+        enabled_rules = [rule for rule in rules if rule.get("enabled", True)]
+
         if not enabled_rules:
-            return {'message': 'No enabled rules found', 'emails_processed': 0, 'actions_taken': 0}
-        
+            return {"message": "No enabled rules found", "emails_processed": 0, "actions_taken": 0}
+
         # Get all emails for processing
         emails = self.search_emails("ALL", mailbox, limit)
         if not emails or (len(emails) == 1 and "error" in emails[0]):
-            return {'error': 'Failed to retrieve emails'}
-        
-        email_ids = [email['id'] for email in emails]
+            return {"error": "Failed to retrieve emails"}
+
+        email_ids = [email["id"] for email in emails]
         total_processed = 0
         total_actions = 0
         all_bulk_results = {}
-        
+
         # Process emails in chunks to manage memory
         for i in range(0, len(email_ids), chunk_size):
-            chunk_ids = email_ids[i:i + chunk_size]
-            logger.info(f"Processing chunk {i//chunk_size + 1}/{(len(email_ids) + chunk_size - 1)//chunk_size}: {len(chunk_ids)} emails")
-            
+            chunk_ids = email_ids[i : i + chunk_size]
+            logger.info(
+                f"Processing chunk {i // chunk_size + 1}/{(len(email_ids) + chunk_size - 1) // chunk_size}: {len(chunk_ids)} emails"
+            )
+
             # Apply rules to this chunk
             chunk_result = self.apply_filter_rules_to_chunk(chunk_ids, enabled_rules, mailbox)
-            
-            total_processed += chunk_result.get('emails_processed', 0)
-            total_actions += chunk_result.get('actions_taken', 0)
-            
+
+            total_processed += chunk_result.get("emails_processed", 0)
+            total_actions += chunk_result.get("actions_taken", 0)
+
             # Merge bulk results
-            for action_type, result in chunk_result.get('bulk_results', {}).items():
+            for action_type, result in chunk_result.get("bulk_results", {}).items():
                 if action_type not in all_bulk_results:
-                    all_bulk_results[action_type] = {'moved': 0, 'marked': 0, 'deleted': 0, 'failed': 0}
-                
-                for key in ['moved', 'marked', 'deleted', 'failed']:
+                    all_bulk_results[action_type] = {"moved": 0, "marked": 0, "deleted": 0, "failed": 0}
+
+                for key in ["moved", "marked", "deleted", "failed"]:
                     if key in result:
                         all_bulk_results[action_type][key] = all_bulk_results[action_type].get(key, 0) + result[key]
-        
+
         # Save updated rule statistics
         self.save_filter_rules(rules)
-        
+
         return {
-            'emails_processed': total_processed,
-            'actions_taken': total_actions,
-            'bulk_results': all_bulk_results,
-            'chunks_processed': (len(email_ids) + chunk_size - 1) // chunk_size
+            "emails_processed": total_processed,
+            "actions_taken": total_actions,
+            "bulk_results": all_bulk_results,
+            "chunks_processed": (len(email_ids) + chunk_size - 1) // chunk_size,
         }
-    
-    def apply_filter_rules_to_chunk(self, email_ids: List[str], rules: List[Dict], mailbox: str) -> Dict[str, Any]:
+
+    def apply_filter_rules_to_chunk(self, email_ids: list[str], rules: list[dict], mailbox: str) -> dict[str, Any]:
         """Apply filter rules to a chunk of emails"""
         # Bulk retrieve emails for this chunk
         full_emails = self.get_bulk_emails(email_ids, mailbox)
-        
+
         if not full_emails:
-            return {'emails_processed': 0, 'actions_taken': 0, 'bulk_results': {}}
-        
+            return {"emails_processed": 0, "actions_taken": 0, "bulk_results": {}}
+
         # Group actions for bulk execution
-        bulk_actions = {
-            'move_to_folder': {},
-            'mark_as_read': [],
-            'mark_as_important': [],
-            'delete': []
-        }
-        
+        bulk_actions = {"move_to_folder": {}, "mark_as_read": [], "mark_as_important": [], "delete": []}
+
         # Process emails against rules
         for email_id, full_email in full_emails.items():
             for rule in rules:
                 if self.email_matches_rule(full_email, rule):
-                    actions = rule.get('actions', {})
-                    
+                    actions = rule.get("actions", {})
+
                     for action, value in actions.items():
-                        if action == 'move_to_folder' and value:
-                            if value not in bulk_actions['move_to_folder']:
-                                bulk_actions['move_to_folder'][value] = []
-                            bulk_actions['move_to_folder'][value].append(email_id)
-                        elif action == 'mark_as_read' and value:
-                            bulk_actions['mark_as_read'].append(email_id)
-                        elif action == 'mark_as_important' and value:
-                            bulk_actions['mark_as_important'].append(email_id)
-                        elif action == 'delete' and value:
-                            bulk_actions['delete'].append(email_id)
-        
+                        if action == "move_to_folder" and value:
+                            if value not in bulk_actions["move_to_folder"]:
+                                bulk_actions["move_to_folder"][value] = []
+                            bulk_actions["move_to_folder"][value].append(email_id)
+                        elif action == "mark_as_read" and value:
+                            bulk_actions["mark_as_read"].append(email_id)
+                        elif action == "mark_as_important" and value:
+                            bulk_actions["mark_as_important"].append(email_id)
+                        elif action == "delete" and value:
+                            bulk_actions["delete"].append(email_id)
+
         # Execute bulk actions for this chunk
         actions_taken = 0
         bulk_results = {}
-        
-        for target_folder, move_ids in bulk_actions['move_to_folder'].items():
+
+        for target_folder, move_ids in bulk_actions["move_to_folder"].items():
             if move_ids:
                 result = self.bulk_move_emails(move_ids, target_folder, mailbox)
-                bulk_results[f'move_to_{target_folder}'] = result
-                actions_taken += result.get('moved', 0)
-        
-        if bulk_actions['mark_as_read']:
-            result = self.bulk_mark_emails(bulk_actions['mark_as_read'], '\\Seen', 'add', mailbox)
-            bulk_results['mark_as_read'] = result
-            actions_taken += result.get('marked', 0)
-        
-        if bulk_actions['mark_as_important']:
-            result = self.bulk_mark_emails(bulk_actions['mark_as_important'], '\\Flagged', 'add', mailbox)
-            bulk_results['mark_as_important'] = result
-            actions_taken += result.get('marked', 0)
-        
-        if bulk_actions['delete']:
-            result = self.bulk_delete_emails(bulk_actions['delete'], mailbox)
-            bulk_results['delete'] = result
-            actions_taken += result.get('deleted', 0)
-        
-        return {
-            'emails_processed': len(full_emails),
-            'actions_taken': actions_taken,
-            'bulk_results': bulk_results
-        }
-    
+                bulk_results[f"move_to_{target_folder}"] = result
+                actions_taken += result.get("moved", 0)
+
+        if bulk_actions["mark_as_read"]:
+            result = self.bulk_mark_emails(bulk_actions["mark_as_read"], "\\Seen", "add", mailbox)
+            bulk_results["mark_as_read"] = result
+            actions_taken += result.get("marked", 0)
+
+        if bulk_actions["mark_as_important"]:
+            result = self.bulk_mark_emails(bulk_actions["mark_as_important"], "\\Flagged", "add", mailbox)
+            bulk_results["mark_as_important"] = result
+            actions_taken += result.get("marked", 0)
+
+        if bulk_actions["delete"]:
+            result = self.bulk_delete_emails(bulk_actions["delete"], mailbox)
+            bulk_results["delete"] = result
+            actions_taken += result.get("deleted", 0)
+
+        return {"emails_processed": len(full_emails), "actions_taken": actions_taken, "bulk_results": bulk_results}
+
     def get_full_email_with_html(self, email_id: str, mailbox: str = "INBOX"):
         """Get full email content including HTML parts for link extraction"""
         mail = self.connect_imap()
         mailbox_selected = False
         try:
             status, response = mail.select(mailbox)
-            if status != 'OK':
+            if status != "OK":
                 logger.error(f"Failed to select mailbox '{mailbox}': {response}")
                 return None
             mailbox_selected = True
-            
-            status, msg_data = mail.fetch(email_id, '(RFC822)')
-            
-            if status != 'OK':
+
+            status, msg_data = mail.fetch(email_id, "(RFC822)")
+
+            if status != "OK":
                 return None
-            
+
             raw_email = msg_data[0][1]
             email_message = email.message_from_bytes(raw_email)
-            
+
             # Extract both text and HTML content
             text_content = ""
             html_content = ""
-            
+
             if email_message.is_multipart():
                 for part in email_message.walk():
                     content_type = part.get_content_type()
                     content_disposition = str(part.get("Content-Disposition"))
-                    
+
                     if "attachment" not in content_disposition:
                         try:
                             payload = part.get_payload(decode=True)
                             if payload:
-                                content = payload.decode('utf-8', errors='ignore')
+                                content = payload.decode("utf-8", errors="ignore")
                                 if content_type == "text/plain":
                                     text_content += content
                                 elif content_type == "text/html":
@@ -1225,71 +1240,63 @@ class ProtonEmailClient:
                 try:
                     payload = email_message.get_payload(decode=True)
                     if payload:
-                        content = payload.decode('utf-8', errors='ignore')
+                        content = payload.decode("utf-8", errors="ignore")
                         if email_message.get_content_type() == "text/html":
                             html_content = content
                         else:
                             text_content = content
                 except Exception:
                     pass
-            
+
             return {
-                'id': email_id,
-                'subject': self.decode_mime_words(email_message['Subject']),
-                'from': self.decode_mime_words(email_message['From']),
-                'to': self.decode_mime_words(email_message['To']),
-                'date': email_message['Date'],
-                'text_body': text_content,
-                'html_body': html_content,
-                'list_unsubscribe': email_message.get('List-Unsubscribe', ''),
-                'list_unsubscribe_post': email_message.get('List-Unsubscribe-Post', '')
+                "id": email_id,
+                "subject": self.decode_mime_words(email_message["Subject"]),
+                "from": self.decode_mime_words(email_message["From"]),
+                "to": self.decode_mime_words(email_message["To"]),
+                "date": email_message["Date"],
+                "text_body": text_content,
+                "html_body": html_content,
+                "list_unsubscribe": email_message.get("List-Unsubscribe", ""),
+                "list_unsubscribe_post": email_message.get("List-Unsubscribe-Post", ""),
             }
         finally:
             if mailbox_selected:
                 mail.close()
             mail.logout()
-    
-    def find_unsubscribe_links(self, email_data: Dict) -> Dict[str, Any]:
+
+    def find_unsubscribe_links(self, email_data: dict) -> dict[str, Any]:
         """
         Find unsubscribe links and methods in an email.
         Returns various unsubscribe options found.
         """
         unsubscribe_methods = []
-        
+
         # Check List-Unsubscribe header (RFC 2369)
-        list_unsubscribe = email_data.get('list_unsubscribe', '')
+        list_unsubscribe = email_data.get("list_unsubscribe", "")
         if list_unsubscribe:
             # Parse mailto and HTTP URLs from List-Unsubscribe header
-            mailto_matches = re.findall(r'<mailto:([^>]+)>', list_unsubscribe)
-            http_matches = re.findall(r'<(https?://[^>]+)>', list_unsubscribe)
-            
+            mailto_matches = re.findall(r"<mailto:([^>]+)>", list_unsubscribe)
+            http_matches = re.findall(r"<(https?://[^>]+)>", list_unsubscribe)
+
             for mailto in mailto_matches:
-                unsubscribe_methods.append({
-                    'type': 'mailto',
-                    'address': mailto,
-                    'method': 'email'
-                })
-            
+                unsubscribe_methods.append({"type": "mailto", "address": mailto, "method": "email"})
+
             for url in http_matches:
-                unsubscribe_methods.append({
-                    'type': 'http',
-                    'url': url,
-                    'method': 'click'
-                })
-        
+                unsubscribe_methods.append({"type": "http", "url": url, "method": "click"})
+
         # Check for one-click unsubscribe (RFC 8058)
-        list_unsubscribe_post = email_data.get('list_unsubscribe_post', '')
-        if list_unsubscribe_post and 'List-Unsubscribe=One-Click' in list_unsubscribe_post:
+        list_unsubscribe_post = email_data.get("list_unsubscribe_post", "")
+        if list_unsubscribe_post and "List-Unsubscribe=One-Click" in list_unsubscribe_post:
             # Find the corresponding HTTP URL for one-click
             for method in unsubscribe_methods:
-                if method['type'] == 'http':
-                    method['one_click'] = True
-                    method['method'] = 'one_click'
-        
+                if method["type"] == "http":
+                    method["one_click"] = True
+                    method["method"] = "one_click"
+
         # Extract unsubscribe links from email body
-        text_body = email_data.get('text_body', '')
-        html_body = email_data.get('html_body', '')
-        
+        text_body = email_data.get("text_body", "")
+        html_body = email_data.get("html_body", "")
+
         # Common unsubscribe link patterns
         unsubscribe_patterns = [
             r'(?i)unsubscribe.*?https?://[^\s<>"]+',
@@ -1297,7 +1304,7 @@ class ProtonEmailClient:
             r'(?i)https?://[^\s<>"]*opt.?out[^\s<>"]*',
             r'(?i)https?://[^\s<>"]*remove[^\s<>"]*',
         ]
-        
+
         # Search in HTML content for href attributes
         if html_body:
             html_unsubscribe_patterns = [
@@ -1305,18 +1312,15 @@ class ProtonEmailClient:
                 r'(?i)<a[^>]*href=["\']([^"\']*opt.?out[^"\']*)["\'][^>]*>',
                 r'(?i)<a[^>]*href=["\']([^"\']*remove[^"\']*)["\'][^>]*>',
             ]
-            
+
             for pattern in html_unsubscribe_patterns:
                 matches = re.findall(pattern, html_body)
                 for match in matches:
-                    if match.startswith('http'):
-                        unsubscribe_methods.append({
-                            'type': 'http',
-                            'url': match,
-                            'method': 'click',
-                            'source': 'html_body'
-                        })
-        
+                    if match.startswith("http"):
+                        unsubscribe_methods.append(
+                            {"type": "http", "url": match, "method": "click", "source": "html_body"}
+                        )
+
         # Search in text content
         for pattern in unsubscribe_patterns:
             matches = re.findall(pattern, text_body)
@@ -1324,31 +1328,28 @@ class ProtonEmailClient:
                 # Extract just the URL part
                 url_match = re.search(r'https?://[^\s<>"]+', match)
                 if url_match:
-                    unsubscribe_methods.append({
-                        'type': 'http',
-                        'url': url_match.group(),
-                        'method': 'click',
-                        'source': 'text_body'
-                    })
-        
+                    unsubscribe_methods.append(
+                        {"type": "http", "url": url_match.group(), "method": "click", "source": "text_body"}
+                    )
+
         # Remove duplicates
         seen_urls = set()
         unique_methods = []
         for method in unsubscribe_methods:
-            identifier = method.get('url') or method.get('address')
+            identifier = method.get("url") or method.get("address")
             if identifier not in seen_urls:
                 seen_urls.add(identifier)
                 unique_methods.append(method)
-        
+
         return {
-            'email_id': email_data.get('id'),
-            'subject': email_data.get('subject'),
-            'from': email_data.get('from'),
-            'unsubscribe_methods': unique_methods,
-            'total_methods': len(unique_methods),
-            'has_one_click': any(method.get('one_click', False) for method in unique_methods)
+            "email_id": email_data.get("id"),
+            "subject": email_data.get("subject"),
+            "from": email_data.get("from"),
+            "unsubscribe_methods": unique_methods,
+            "total_methods": len(unique_methods),
+            "has_one_click": any(method.get("one_click", False) for method in unique_methods),
         }
-    
+
     def _is_safe_url(self, url: str) -> bool:
         """
         Validate that a URL is safe to request (not targeting internal/private networks).
@@ -1360,7 +1361,7 @@ class ProtonEmailClient:
             return False
 
         # Only allow http and https schemes
-        if parsed.scheme not in ('http', 'https'):
+        if parsed.scheme not in ("http", "https"):
             logging.warning(f"Blocked URL with non-HTTP scheme: {parsed.scheme}")
             return False
 
@@ -1369,7 +1370,7 @@ class ProtonEmailClient:
             return False
 
         # Reject localhost variants
-        if hostname in ('localhost', 'localhost.localdomain'):
+        if hostname in ("localhost", "localhost.localdomain"):
             logging.warning(f"Blocked request to localhost: {url}")
             return False
 
@@ -1394,103 +1395,104 @@ class ProtonEmailClient:
 
         return True
 
-    def execute_unsubscribe(self, unsubscribe_method: Dict, timeout: int = 10) -> Dict[str, Any]:
+    def execute_unsubscribe(self, unsubscribe_method: dict, timeout: int = 10) -> dict[str, Any]:
         """
         Execute an unsubscribe request.
         """
-        result = {
-            'method': unsubscribe_method,
-            'success': False,
-            'message': '',
-            'status_code': None
-        }
-        
+        result = {"method": unsubscribe_method, "success": False, "message": "", "status_code": None}
+
         try:
-            if unsubscribe_method['type'] == 'mailto':
+            if unsubscribe_method["type"] == "mailto":
                 # For mailto unsubscribe, we would send an email
                 # This is more complex and requires careful handling
-                result['message'] = "Mailto unsubscribe requires manual email sending"
-                result['success'] = False
-                
-            elif unsubscribe_method['type'] == 'http':
-                url = unsubscribe_method['url']
+                result["message"] = "Mailto unsubscribe requires manual email sending"
+                result["success"] = False
+
+            elif unsubscribe_method["type"] == "http":
+                url = unsubscribe_method["url"]
 
                 # Validate URL before making any request
                 if not self._is_safe_url(url):
-                    result['message'] = f"Blocked unsafe unsubscribe URL: {url}"
+                    result["message"] = f"Blocked unsafe unsubscribe URL: {url}"
                     return result
 
                 # Set up headers to look like a real browser
                 headers = {
-                    'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36',
-                    'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-                    'Accept-Language': 'en-US,en;q=0.5',
-                    'Accept-Encoding': 'gzip, deflate',
-                    'Connection': 'keep-alive',
+                    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36",
+                    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+                    "Accept-Language": "en-US,en;q=0.5",
+                    "Accept-Encoding": "gzip, deflate",
+                    "Connection": "keep-alive",
                 }
-                
-                if unsubscribe_method.get('one_click'):
+
+                if unsubscribe_method.get("one_click"):
                     # RFC 8058 one-click unsubscribe
-                    headers['List-Unsubscribe'] = 'One-Click'
+                    headers["List-Unsubscribe"] = "One-Click"
                     response = requests.post(url, headers=headers, timeout=timeout, allow_redirects=False)
                 else:
                     # Regular HTTP GET request
                     response = requests.get(url, headers=headers, timeout=timeout, allow_redirects=False)
-                
+
                 # Handle redirects safely
                 if response.status_code in (301, 302, 303, 307, 308):
-                    redirect_url = response.headers.get('Location')
+                    redirect_url = response.headers.get("Location")
                     if redirect_url:
                         if not self._is_safe_url(redirect_url):
-                            result['status_code'] = response.status_code
-                            result['message'] = f"Blocked unsafe redirect to: {redirect_url}"
+                            result["status_code"] = response.status_code
+                            result["message"] = f"Blocked unsafe redirect to: {redirect_url}"
                             return result
                         # Follow the safe redirect
                         response = requests.get(redirect_url, headers=headers, timeout=timeout, allow_redirects=False)
 
-                result['status_code'] = response.status_code
+                result["status_code"] = response.status_code
 
                 if response.status_code in [200, 201, 202, 204]:
-                    result['success'] = True
-                    result['message'] = f"Unsubscribe request successful (HTTP {response.status_code})"
+                    result["success"] = True
+                    result["message"] = f"Unsubscribe request successful (HTTP {response.status_code})"
                 else:
-                    result['message'] = f"Unsubscribe request failed with HTTP {response.status_code}"
-                
+                    result["message"] = f"Unsubscribe request failed with HTTP {response.status_code}"
+
                 # Check response content for confirmation
-                if result['success']:
+                if result["success"]:
                     content = response.text.lower()
                     confirmation_phrases = [
-                        'unsubscribed', 'removed', 'opted out', 'no longer receive',
-                        'successfully unsubscribed', 'email address has been removed'
+                        "unsubscribed",
+                        "removed",
+                        "opted out",
+                        "no longer receive",
+                        "successfully unsubscribed",
+                        "email address has been removed",
                     ]
                     if any(phrase in content for phrase in confirmation_phrases):
-                        result['message'] += " - Confirmation detected in response"
-                
+                        result["message"] += " - Confirmation detected in response"
+
         except requests.exceptions.Timeout:
-            result['message'] = f"Request timed out after {timeout} seconds"
+            result["message"] = f"Request timed out after {timeout} seconds"
         except requests.exceptions.ConnectionError:
-            result['message'] = "Connection error - could not reach unsubscribe URL"
+            result["message"] = "Connection error - could not reach unsubscribe URL"
         except requests.exceptions.RequestException as e:
-            result['message'] = f"Request failed: {str(e)}"
+            result["message"] = f"Request failed: {str(e)}"
         except Exception as e:
-            result['message'] = f"Unexpected error: {str(e)}"
-        
+            result["message"] = f"Unexpected error: {str(e)}"
+
         return result
+
 
 # Initialize email client
 email_client = ProtonEmailClient()
 
+
 # MCP Tools
 @mcp.tool()
-def search_emails(query: str = "ALL", mailbox: str = "INBOX", limit: int = 10) -> List[dict]:
+def search_emails(query: str = "ALL", mailbox: str = "INBOX", limit: int = 10) -> list[dict]:
     """
     Search for emails in your Proton mailbox.
-    
+
     Args:
         query: IMAP search query (e.g., 'FROM "sender@example.com"', 'SUBJECT "important"')
         mailbox: Mailbox to search in (default: INBOX)
         limit: Maximum number of emails to return (default: 10)
-    
+
     Returns:
         List of email summaries with id, subject, from, date, and body preview
     """
@@ -1499,15 +1501,16 @@ def search_emails(query: str = "ALL", mailbox: str = "INBOX", limit: int = 10) -
     except Exception as e:
         return [{"error": f"Failed to search emails: {str(e)}"}]
 
+
 @mcp.tool()
 def get_email_content(email_id: str, mailbox: str = "INBOX") -> dict:
     """
     Get the full content of a specific email.
-    
+
     Args:
         email_id: The ID of the email to retrieve
         mailbox: Mailbox containing the email (default: INBOX)
-    
+
     Returns:
         Full email content including subject, from, to, date, and complete body
     """
@@ -1525,17 +1528,18 @@ def get_email_content(email_id: str, mailbox: str = "INBOX") -> dict:
     except Exception as e:
         return {"error": f"Failed to get email: {str(e)}"}
 
+
 @mcp.tool()
 def send_email(to: str, subject: str, body: str, reply_to_id: str = None) -> dict:
     """
     Send an email via Proton Mail.
-    
+
     Args:
         to: Recipient email address
         subject: Email subject
         body: Email body content
         reply_to_id: Optional ID of email being replied to
-    
+
     Returns:
         Success status and message
     """
@@ -1548,15 +1552,16 @@ def send_email(to: str, subject: str, body: str, reply_to_id: str = None) -> dic
     except Exception as e:
         return {"status": "error", "message": f"Failed to send email: {str(e)}"}
 
+
 @mcp.tool()
-def get_recent_emails(days: int = 7, mailbox: str = "INBOX") -> List[dict]:
+def get_recent_emails(days: int = 7, mailbox: str = "INBOX") -> list[dict]:
     """
     Get recent emails from the specified number of days.
-    
+
     Args:
         days: Number of days back to search (default: 7)
         mailbox: Mailbox to search in (default: INBOX)
-    
+
     Returns:
         List of recent emails
     """
@@ -1567,16 +1572,17 @@ def get_recent_emails(days: int = 7, mailbox: str = "INBOX") -> List[dict]:
     except Exception as e:
         return [{"error": f"Failed to get recent emails: {str(e)}"}]
 
+
 @mcp.tool()
-def filter_junk_emails(mailbox: str = "INBOX", limit: int = 20, action: str = "analyze") -> List[dict]:
+def filter_junk_emails(mailbox: str = "INBOX", limit: int = 20, action: str = "analyze") -> list[dict]:
     """
     Filter and analyze emails for junk/spam content using optimized bulk operations.
-    
+
     Args:
         mailbox: Mailbox to analyze (default: INBOX)
         limit: Maximum number of emails to analyze (default: 20)
         action: Action to take - "analyze" (default) or "move_to_spam"
-    
+
     Returns:
         List of emails with junk analysis results
     """
@@ -1585,61 +1591,58 @@ def filter_junk_emails(mailbox: str = "INBOX", limit: int = 20, action: str = "a
         emails = email_client.search_emails("ALL", mailbox, limit)
         if not emails or (len(emails) == 1 and "error" in emails[0]):
             return emails
-        
+
         # Extract email IDs for bulk retrieval
-        email_ids = [email['id'] for email in emails]
-        
+        email_ids = [email["id"] for email in emails]
+
         # Bulk retrieve full email content
         logger.info(f"Bulk analyzing {len(email_ids)} emails for junk content")
         full_emails = email_client.get_bulk_emails(email_ids, mailbox)
-        
+
         if not full_emails:
             return [{"error": "Failed to retrieve email content for junk analysis"}]
-        
+
         filtered_results = []
         junk_email_ids = []
-        
+
         # Analyze each email for junk
         for email_item in emails:
-            email_id = email_item['id']
+            email_id = email_item["id"]
             full_email = full_emails.get(email_id)
-            
+
             if not full_email:
                 continue
-                
+
             # Analyze for junk
             junk_analysis = email_client.is_junk_email(full_email)
-            
+
             # Add original email data to result
-            result = {
-                **email_item,
-                "junk_analysis": junk_analysis
-            }
-            
+            result = {**email_item, "junk_analysis": junk_analysis}
+
             # Queue junk emails for bulk move
             if action == "move_to_spam" and junk_analysis["is_likely_junk"]:
                 junk_email_ids.append(email_id)
                 result["action_queued"] = "move_to_spam"
-            
+
             filtered_results.append(result)
-        
+
         # Bulk move junk emails if requested
         moved_count = 0
         if action == "move_to_spam" and junk_email_ids:
             logger.info(f"Bulk moving {len(junk_email_ids)} junk emails to Spam folder")
             move_result = email_client.bulk_move_emails(junk_email_ids, "Spam", mailbox)
-            moved_count = move_result.get('moved', 0)
-            
+            moved_count = move_result.get("moved", 0)
+
             # Update results with actual move status
             for result in filtered_results:
                 if result.get("action_queued") == "move_to_spam":
-                    email_id = result['id']
+                    email_id = result["id"]
                     if email_id in junk_email_ids[:moved_count]:  # Successful moves
                         result["action_taken"] = "moved_to_spam"
                     else:
                         result["action_taken"] = "move_failed"
                     result.pop("action_queued", None)
-        
+
         # Add summary
         junk_count = sum(1 for r in filtered_results if r["junk_analysis"]["is_likely_junk"])
         summary = {
@@ -1647,25 +1650,26 @@ def filter_junk_emails(mailbox: str = "INBOX", limit: int = 20, action: str = "a
                 "total_analyzed": len(filtered_results),
                 "junk_detected": junk_count,
                 "moved_to_spam": moved_count if action == "move_to_spam" else 0,
-                "move_failed": len(junk_email_ids) - moved_count if action == "move_to_spam" else 0
+                "move_failed": len(junk_email_ids) - moved_count if action == "move_to_spam" else 0,
             }
         }
         filtered_results.insert(0, summary)
-        
+
         return filtered_results
     except Exception as e:
         return [{"error": f"Failed to filter junk emails: {str(e)}"}]
+
 
 @mcp.tool()
 def move_email_to_folder(email_id: str, target_folder: str, source_folder: str = "INBOX") -> dict:
     """
     Move a specific email to a different folder.
-    
+
     Args:
         email_id: The ID of the email to move
         target_folder: Target folder name (e.g., "Spam", "Trash", "Archive")
         source_folder: Source folder name (default: INBOX)
-    
+
     Returns:
         Status of the move operation
     """
@@ -1679,23 +1683,18 @@ def move_email_to_folder(email_id: str, target_folder: str, source_folder: str =
     try:
         success = email_client.move_email_to_folder(email_id, target_folder, source_folder)
         if success:
-            return {
-                "status": "success", 
-                "message": f"Email {email_id} moved from {source_folder} to {target_folder}"
-            }
+            return {"status": "success", "message": f"Email {email_id} moved from {source_folder} to {target_folder}"}
         else:
-            return {
-                "status": "error", 
-                "message": f"Failed to move email {email_id}"
-            }
+            return {"status": "error", "message": f"Failed to move email {email_id}"}
     except Exception as e:
         return {"status": "error", "message": f"Error moving email: {str(e)}"}
 
+
 @mcp.tool()
-def get_mailboxes() -> List[str]:
+def get_mailboxes() -> list[str]:
     """
     Get list of available mailboxes/folders.
-    
+
     Returns:
         List of mailbox names
     """
@@ -1704,14 +1703,15 @@ def get_mailboxes() -> List[str]:
     except Exception as e:
         return [f"Error: {str(e)}"]
 
+
 @mcp.tool()
 def create_folder(folder_name: str) -> dict:
     """
     Create a new email folder/mailbox.
-    
+
     Args:
         folder_name: Name of the folder to create
-    
+
     Returns:
         Status of the folder creation operation
     """
@@ -1723,26 +1723,21 @@ def create_folder(folder_name: str) -> dict:
     try:
         success = email_client.create_folder(folder_name)
         if success:
-            return {
-                "status": "success",
-                "message": f"Folder '{folder_name}' created successfully"
-            }
+            return {"status": "success", "message": f"Folder '{folder_name}' created successfully"}
         else:
-            return {
-                "status": "error",
-                "message": f"Failed to create folder '{folder_name}'"
-            }
+            return {"status": "error", "message": f"Failed to create folder '{folder_name}'"}
     except Exception as e:
         return {"status": "error", "message": f"Error creating folder: {str(e)}"}
+
 
 @mcp.tool()
 def delete_folder(folder_name: str) -> dict:
     """
     Delete an existing email folder/mailbox.
-    
+
     Args:
         folder_name: Name of the folder to delete
-    
+
     Returns:
         Status of the folder deletion operation
     """
@@ -1754,27 +1749,22 @@ def delete_folder(folder_name: str) -> dict:
     try:
         success = email_client.delete_folder(folder_name)
         if success:
-            return {
-                "status": "success",
-                "message": f"Folder '{folder_name}' deleted successfully"
-            }
+            return {"status": "success", "message": f"Folder '{folder_name}' deleted successfully"}
         else:
-            return {
-                "status": "error",
-                "message": f"Failed to delete folder '{folder_name}'"
-            }
+            return {"status": "error", "message": f"Failed to delete folder '{folder_name}'"}
     except Exception as e:
         return {"status": "error", "message": f"Error deleting folder: {str(e)}"}
+
 
 @mcp.tool()
 def analyze_email_for_junk(email_id: str, mailbox: str = "INBOX") -> dict:
     """
     Analyze a specific email for junk/spam indicators.
-    
+
     Args:
         email_id: The ID of the email to analyze
         mailbox: Mailbox containing the email (default: INBOX)
-    
+
     Returns:
         Detailed junk analysis for the email
     """
@@ -1788,33 +1778,36 @@ def analyze_email_for_junk(email_id: str, mailbox: str = "INBOX") -> dict:
         email_data = email_client.get_full_email(email_id, mailbox)
         if not email_data:
             return {"error": "Email not found"}
-        
+
         # Analyze for junk
         junk_analysis = email_client.is_junk_email(email_data)
-        
+
         return {
             "email": {
                 "id": email_data["id"],
                 "subject": email_data["subject"],
                 "from": email_data["from"],
-                "date": email_data["date"]
+                "date": email_data["date"],
             },
-            "junk_analysis": junk_analysis
+            "junk_analysis": junk_analysis,
         }
     except Exception as e:
         return {"error": f"Failed to analyze email: {str(e)}"}
 
+
 @mcp.tool()
-def search_emails_filtered(query: str = "ALL", mailbox: str = "INBOX", limit: int = 10, exclude_junk: bool = False) -> List[dict]:
+def search_emails_filtered(
+    query: str = "ALL", mailbox: str = "INBOX", limit: int = 10, exclude_junk: bool = False
+) -> list[dict]:
     """
     Search for emails with optional junk filtering.
-    
+
     Args:
         query: IMAP search query (e.g., 'FROM "sender@example.com"', 'SUBJECT "important"')
-        mailbox: Mailbox to search in (default: INBOX)  
+        mailbox: Mailbox to search in (default: INBOX)
         limit: Maximum number of emails to return (default: 10)
         exclude_junk: If True, filter out likely junk emails (default: False)
-    
+
     Returns:
         List of email summaries, optionally filtered for junk
     """
@@ -1822,36 +1815,37 @@ def search_emails_filtered(query: str = "ALL", mailbox: str = "INBOX", limit: in
         emails = email_client.search_emails(query, mailbox, limit if not exclude_junk else limit * 2)
         if not emails or (len(emails) == 1 and "error" in emails[0]):
             return emails
-        
+
         if not exclude_junk:
             return emails
-        
+
         # Filter out junk emails
         filtered_emails = []
         for email_item in emails:
             if len(filtered_emails) >= limit:
                 break
-                
+
             # Get full email content for junk analysis
-            full_email = email_client.get_full_email(email_item['id'], mailbox)
+            full_email = email_client.get_full_email(email_item["id"], mailbox)
             if full_email:
                 junk_analysis = email_client.is_junk_email(full_email)
                 if not junk_analysis["is_likely_junk"]:
                     filtered_emails.append(email_item)
-        
+
         return filtered_emails
     except Exception as e:
         return [{"error": f"Failed to search emails: {str(e)}"}]
+
 
 @mcp.tool()
 def find_unsubscribe_links(email_id: str, mailbox: str = "INBOX") -> dict:
     """
     Find unsubscribe links and methods in a specific email.
-    
+
     Args:
         email_id: The ID of the email to analyze
         mailbox: Mailbox containing the email (default: INBOX)
-    
+
     Returns:
         Dictionary with unsubscribe methods found
     """
@@ -1865,25 +1859,26 @@ def find_unsubscribe_links(email_id: str, mailbox: str = "INBOX") -> dict:
         email_data = email_client.get_full_email_with_html(email_id, mailbox)
         if not email_data:
             return {"error": "Email not found"}
-        
+
         # Find unsubscribe methods
         unsubscribe_info = email_client.find_unsubscribe_links(email_data)
-        
+
         return unsubscribe_info
     except Exception as e:
         return {"error": f"Failed to find unsubscribe links: {str(e)}"}
+
 
 @mcp.tool()
 def unsubscribe_from_email(email_id: str, mailbox: str = "INBOX", method_index: int = 0, confirm: bool = False) -> dict:
     """
     Unsubscribe from a mailing list using links found in an email.
-    
+
     Args:
         email_id: The ID of the email containing unsubscribe links
         mailbox: Mailbox containing the email (default: INBOX)
         method_index: Index of unsubscribe method to use (default: 0 for first method)
         confirm: Must be True to actually execute unsubscribe (safety measure)
-    
+
     Returns:
         Result of unsubscribe attempt
     """
@@ -1896,50 +1891,47 @@ def unsubscribe_from_email(email_id: str, mailbox: str = "INBOX", method_index: 
         if not confirm:
             return {
                 "error": "Safety measure: set confirm=True to execute unsubscribe",
-                "message": "Use find_unsubscribe_links first to see available methods"
+                "message": "Use find_unsubscribe_links first to see available methods",
             }
-        
+
         # Get full email content with HTML
         email_data = email_client.get_full_email_with_html(email_id, mailbox)
         if not email_data:
             return {"error": "Email not found"}
-        
+
         # Find unsubscribe methods
         unsubscribe_info = email_client.find_unsubscribe_links(email_data)
-        
-        if not unsubscribe_info['unsubscribe_methods']:
+
+        if not unsubscribe_info["unsubscribe_methods"]:
             return {"error": "No unsubscribe methods found in this email"}
-        
-        if method_index >= len(unsubscribe_info['unsubscribe_methods']):
+
+        if method_index >= len(unsubscribe_info["unsubscribe_methods"]):
             return {
-                "error": f"Method index {method_index} out of range. Available methods: 0-{len(unsubscribe_info['unsubscribe_methods'])-1}"
+                "error": f"Method index {method_index} out of range. Available methods: 0-{len(unsubscribe_info['unsubscribe_methods']) - 1}"
             }
-        
+
         # Execute unsubscribe
-        method = unsubscribe_info['unsubscribe_methods'][method_index]
+        method = unsubscribe_info["unsubscribe_methods"][method_index]
         result = email_client.execute_unsubscribe(method)
-        
+
         return {
-            "email_info": {
-                "id": email_data['id'],
-                "subject": email_data['subject'],
-                "from": email_data['from']
-            },
-            "unsubscribe_result": result
+            "email_info": {"id": email_data["id"], "subject": email_data["subject"], "from": email_data["from"]},
+            "unsubscribe_result": result,
         }
     except Exception as e:
         return {"error": f"Failed to unsubscribe: {str(e)}"}
 
+
 @mcp.tool()
-def bulk_find_unsubscribe_opportunities(mailbox: str = "INBOX", days: int = 30, limit: int = 50) -> List[dict]:
+def bulk_find_unsubscribe_opportunities(mailbox: str = "INBOX", days: int = 30, limit: int = 50) -> list[dict]:
     """
     Scan recent emails to find unsubscribe opportunities from mailing lists using bulk operations.
-    
+
     Args:
         mailbox: Mailbox to scan (default: INBOX)
         days: Number of days back to search (default: 30)
         limit: Maximum emails to analyze (default: 50)
-    
+
     Returns:
         List of emails with unsubscribe opportunities
     """
@@ -1948,72 +1940,71 @@ def bulk_find_unsubscribe_opportunities(mailbox: str = "INBOX", days: int = 30, 
         since_date = (datetime.now() - timedelta(days=days)).strftime("%d-%b-%Y")
         query = f'SINCE "{since_date}"'
         emails = email_client.search_emails(query, mailbox, limit)
-        
+
         if not emails or (len(emails) == 1 and "error" in emails[0]):
             return emails
-        
+
         # Extract email IDs for bulk retrieval
-        email_ids = [email['id'] for email in emails]
-        
+        email_ids = [email["id"] for email in emails]
+
         # Bulk retrieve emails with HTML content
         logger.info(f"Bulk analyzing {len(email_ids)} emails for unsubscribe opportunities")
         full_emails = email_client.get_bulk_emails_with_html(email_ids, mailbox)
-        
+
         if not full_emails:
             return [{"error": "Failed to retrieve email content for unsubscribe analysis"}]
-        
+
         unsubscribe_opportunities = []
         processed = 0
-        
+
         for email_item in emails:
-            email_id = email_item['id']
+            email_id = email_item["id"]
             email_data = full_emails.get(email_id)
-            
+
             if not email_data:
                 continue
-            
+
             processed += 1
-            
+
             try:
                 # Find unsubscribe methods
                 unsubscribe_info = email_client.find_unsubscribe_links(email_data)
-                
-                if unsubscribe_info['total_methods'] > 0:
+
+                if unsubscribe_info["total_methods"] > 0:
                     # Add basic email info
-                    opportunity = {
-                        **email_item,
-                        "unsubscribe_info": unsubscribe_info
-                    }
+                    opportunity = {**email_item, "unsubscribe_info": unsubscribe_info}
                     unsubscribe_opportunities.append(opportunity)
-                    
+
             except Exception as e:
                 logger.warning(f"Failed to analyze email {email_id}: {e}")
                 continue
-        
+
         # Add summary
         summary = {
             "summary": {
                 "emails_analyzed": processed,
                 "unsubscribe_opportunities": len(unsubscribe_opportunities),
-                "one_click_available": sum(1 for opp in unsubscribe_opportunities 
-                                         if opp["unsubscribe_info"]["has_one_click"])
+                "one_click_available": sum(
+                    1 for opp in unsubscribe_opportunities if opp["unsubscribe_info"]["has_one_click"]
+                ),
             }
         }
-        
+
         return [summary] + unsubscribe_opportunities
     except Exception as e:
         return [{"error": f"Failed to find unsubscribe opportunities: {str(e)}"}]
 
+
 @mcp.tool()
-def get_mailing_list_senders(mailbox: str = "INBOX", days: int = 30, min_emails: int = 2) -> List[dict]:
+def get_mailing_list_senders(mailbox: str = "INBOX", days: int = 30, min_emails: int = 2) -> list[dict]:
     """
     Identify frequent senders that might be mailing lists.
-    
+
     Args:
         mailbox: Mailbox to analyze (default: INBOX)
         days: Number of days back to analyze (default: 30)
         min_emails: Minimum number of emails to consider sender as mailing list (default: 2)
-    
+
     Returns:
         List of potential mailing list senders with email counts
     """
@@ -2022,64 +2013,65 @@ def get_mailing_list_senders(mailbox: str = "INBOX", days: int = 30, min_emails:
         since_date = (datetime.now() - timedelta(days=days)).strftime("%d-%b-%Y")
         query = f'SINCE "{since_date}"'
         emails = email_client.search_emails(query, mailbox, 200)  # Higher limit for analysis
-        
+
         if not emails or (len(emails) == 1 and "error" in emails[0]):
             return emails
-        
+
         # Count emails per sender
         sender_counts = {}
         for email_item in emails:
-            from_addr = email_item.get('from', '').strip()
+            from_addr = email_item.get("from", "").strip()
             if from_addr:
                 if from_addr not in sender_counts:
-                    sender_counts[from_addr] = {
-                        'count': 0,
-                        'subjects': [],
-                        'latest_date': email_item.get('date', '')
-                    }
-                sender_counts[from_addr]['count'] += 1
-                sender_counts[from_addr]['subjects'].append(email_item.get('subject', 'No Subject'))
-        
+                    sender_counts[from_addr] = {"count": 0, "subjects": [], "latest_date": email_item.get("date", "")}
+                sender_counts[from_addr]["count"] += 1
+                sender_counts[from_addr]["subjects"].append(email_item.get("subject", "No Subject"))
+
         # Filter for potential mailing lists
         mailing_lists = []
         for sender, data in sender_counts.items():
-            if data['count'] >= min_emails:
+            if data["count"] >= min_emails:
                 # Check for mailing list indicators
-                is_likely_mailing_list = any([
-                    'newsletter' in sender.lower(),
-                    'noreply' in sender.lower(),
-                    'marketing' in sender.lower(),
-                    'updates' in sender.lower(),
-                    'notifications' in sender.lower(),
-                    data['count'] >= 5  # High volume sender
-                ])
-                
-                mailing_lists.append({
-                    'sender': sender,
-                    'email_count': data['count'],
-                    'likely_mailing_list': is_likely_mailing_list,
-                    'latest_date': data['latest_date'],
-                    'sample_subjects': data['subjects'][:3]  # First 3 subjects as sample
-                })
-        
+                is_likely_mailing_list = any(
+                    [
+                        "newsletter" in sender.lower(),
+                        "noreply" in sender.lower(),
+                        "marketing" in sender.lower(),
+                        "updates" in sender.lower(),
+                        "notifications" in sender.lower(),
+                        data["count"] >= 5,  # High volume sender
+                    ]
+                )
+
+                mailing_lists.append(
+                    {
+                        "sender": sender,
+                        "email_count": data["count"],
+                        "likely_mailing_list": is_likely_mailing_list,
+                        "latest_date": data["latest_date"],
+                        "sample_subjects": data["subjects"][:3],  # First 3 subjects as sample
+                    }
+                )
+
         # Sort by email count (descending)
-        mailing_lists.sort(key=lambda x: x['email_count'], reverse=True)
-        
+        mailing_lists.sort(key=lambda x: x["email_count"], reverse=True)
+
         return mailing_lists
     except Exception as e:
         return [{"error": f"Failed to analyze mailing list senders: {str(e)}"}]
+
 
 @mcp.tool()
 def create_filter_rule(rule_name: str, conditions: str, actions: str, enabled: bool = True) -> dict:
     """
     Create a new email filtering rule.
-    
+
     Args:
         rule_name: Unique name for the rule
         conditions: JSON string of conditions to match (e.g., '{"from": "newsletter@example.com", "subject_contains": "sale"}')
         actions: JSON string of actions to take (e.g., '{"move_to_folder": "Promotions", "mark_as_read": true}')
         enabled: Whether the rule is active (default: True)
-    
+
     Returns:
         Status of rule creation
     """
@@ -2087,35 +2079,28 @@ def create_filter_rule(rule_name: str, conditions: str, actions: str, enabled: b
         # Parse JSON strings
         conditions_dict = json.loads(conditions)
         actions_dict = json.loads(actions)
-        
+
         success = email_client.create_filter_rule(rule_name, conditions_dict, actions_dict, enabled)
-        
+
         if success:
             return {
                 "status": "success",
                 "message": f"Filter rule '{rule_name}' created successfully",
-                "rule": {
-                    "name": rule_name,
-                    "conditions": conditions_dict,
-                    "actions": actions_dict,
-                    "enabled": enabled
-                }
+                "rule": {"name": rule_name, "conditions": conditions_dict, "actions": actions_dict, "enabled": enabled},
             }
         else:
-            return {
-                "status": "error",
-                "message": f"Failed to create filter rule '{rule_name}'"
-            }
+            return {"status": "error", "message": f"Failed to create filter rule '{rule_name}'"}
     except json.JSONDecodeError as e:
         return {"status": "error", "message": f"Invalid JSON format: {str(e)}"}
     except Exception as e:
         return {"status": "error", "message": f"Error creating filter rule: {str(e)}"}
 
+
 @mcp.tool()
-def list_filter_rules() -> List[dict]:
+def list_filter_rules() -> list[dict]:
     """
     Get list of all filtering rules.
-    
+
     Returns:
         List of all filter rules with their details
     """
@@ -2125,90 +2110,86 @@ def list_filter_rules() -> List[dict]:
     except Exception as e:
         return [{"error": f"Failed to load filter rules: {str(e)}"}]
 
+
 @mcp.tool()
 def delete_filter_rule(rule_id: str) -> dict:
     """
     Delete a filtering rule by ID.
-    
+
     Args:
         rule_id: ID of the rule to delete
-    
+
     Returns:
         Status of rule deletion
     """
     try:
         success = email_client.delete_filter_rule(rule_id)
-        
+
         if success:
-            return {
-                "status": "success",
-                "message": f"Filter rule with ID '{rule_id}' deleted successfully"
-            }
+            return {"status": "success", "message": f"Filter rule with ID '{rule_id}' deleted successfully"}
         else:
-            return {
-                "status": "error",
-                "message": f"Failed to delete filter rule with ID '{rule_id}' (rule not found)"
-            }
+            return {"status": "error", "message": f"Failed to delete filter rule with ID '{rule_id}' (rule not found)"}
     except Exception as e:
         return {"status": "error", "message": f"Error deleting filter rule: {str(e)}"}
 
+
 @mcp.tool()
-def update_filter_rule(rule_id: str, enabled: bool = None, rule_name: str = None, conditions: str = None, actions: str = None) -> dict:
+def update_filter_rule(
+    rule_id: str, enabled: bool = None, rule_name: str = None, conditions: str = None, actions: str = None
+) -> dict:
     """
     Update an existing filtering rule.
-    
+
     Args:
         rule_id: ID of the rule to update
         enabled: Whether the rule should be enabled (optional)
         rule_name: New name for the rule (optional)
         conditions: New conditions JSON string (optional)
         actions: New actions JSON string (optional)
-    
+
     Returns:
         Status of rule update
     """
     try:
         updates = {}
-        
+
         if enabled is not None:
-            updates['enabled'] = enabled
+            updates["enabled"] = enabled
         if rule_name is not None:
-            updates['name'] = rule_name
+            updates["name"] = rule_name
         if conditions is not None:
-            updates['conditions'] = json.loads(conditions)
+            updates["conditions"] = json.loads(conditions)
         if actions is not None:
-            updates['actions'] = json.loads(actions)
-        
+            updates["actions"] = json.loads(actions)
+
         if not updates:
             return {"status": "error", "message": "No updates provided"}
-        
+
         success = email_client.update_filter_rule(rule_id, **updates)
-        
+
         if success:
             return {
                 "status": "success",
                 "message": f"Filter rule with ID '{rule_id}' updated successfully",
-                "updates": updates
+                "updates": updates,
             }
         else:
-            return {
-                "status": "error",
-                "message": f"Failed to update filter rule with ID '{rule_id}' (rule not found)"
-            }
+            return {"status": "error", "message": f"Failed to update filter rule with ID '{rule_id}' (rule not found)"}
     except json.JSONDecodeError as e:
         return {"status": "error", "message": f"Invalid JSON format: {str(e)}"}
     except Exception as e:
         return {"status": "error", "message": f"Error updating filter rule: {str(e)}"}
 
+
 @mcp.tool()
 def apply_filter_rules(mailbox: str = "INBOX", limit: int = 50) -> dict:
     """
     Apply all enabled filtering rules to emails in a mailbox.
-    
+
     Args:
         mailbox: Mailbox to process (default: INBOX)
         limit: Maximum number of emails to process (default: 50)
-    
+
     Returns:
         Summary of rules applied and actions taken
     """
@@ -2218,11 +2199,12 @@ def apply_filter_rules(mailbox: str = "INBOX", limit: int = 50) -> dict:
     except Exception as e:
         return {"error": f"Failed to apply filter rules: {str(e)}"}
 
+
 @mcp.tool()
 def get_filter_rule_examples() -> dict:
     """
     Get examples of common filtering rules to help with rule creation.
-    
+
     Returns:
         Dictionary with example conditions and actions
     """
@@ -2233,44 +2215,45 @@ def get_filter_rule_examples() -> dict:
             "subject_equals": '{"subject_equals": "Weekly Report"}',
             "body_contains": '{"body_contains": "unsubscribe"}',
             "sender_domain": '{"sender_domain": "marketing.company.com"}',
-            "multiple_conditions": '{"from": "updates@github.com", "subject_contains": "Pull Request"}'
+            "multiple_conditions": '{"from": "updates@github.com", "subject_contains": "Pull Request"}',
         },
         "action_examples": {
             "move_to_folder": '{"move_to_folder": "Newsletter"}',
             "mark_as_read": '{"mark_as_read": true}',
             "delete_email": '{"delete": true}',
             "move_and_mark": '{"move_to_folder": "Promotions", "mark_as_read": true}',
-            "mark_important": '{"mark_as_important": true}'
+            "mark_important": '{"mark_as_important": true}',
         },
         "complete_rule_examples": [
             {
                 "name": "GitHub Notifications",
                 "conditions": '{"sender_domain": "github.com"}',
-                "actions": '{"move_to_folder": "GitHub", "mark_as_read": true}'
+                "actions": '{"move_to_folder": "GitHub", "mark_as_read": true}',
             },
             {
                 "name": "Marketing Emails",
                 "conditions": '{"body_contains": "unsubscribe"}',
-                "actions": '{"move_to_folder": "Marketing"}'
+                "actions": '{"move_to_folder": "Marketing"}',
             },
             {
                 "name": "Important Client",
                 "conditions": '{"from": "client@importantcompany.com"}',
-                "actions": '{"move_to_folder": "VIP", "mark_as_important": true}'
-            }
-        ]
+                "actions": '{"move_to_folder": "VIP", "mark_as_important": true}',
+            },
+        ],
     }
+
 
 @mcp.tool()
 def bulk_move_emails(email_ids: str, target_folder: str, source_folder: str = "INBOX") -> dict:
     """
     Move multiple emails to a folder efficiently using bulk operations.
-    
+
     Args:
         email_ids: Comma-separated list of email IDs to move
         target_folder: Destination folder name
         source_folder: Source folder name (default: INBOX)
-    
+
     Returns:
         Dictionary with move operation results
     """
@@ -2283,32 +2266,33 @@ def bulk_move_emails(email_ids: str, target_folder: str, source_folder: str = "I
 
     try:
         # Parse email IDs
-        id_list = [id.strip() for id in email_ids.split(',') if id.strip()]
-        
+        id_list = [id.strip() for id in email_ids.split(",") if id.strip()]
+
         if not id_list:
             return {"error": "No valid email IDs provided"}
-        
+
         result = email_client.bulk_move_emails(id_list, target_folder, source_folder)
         return {
             "status": "success",
-            "moved": result.get('moved', 0),
-            "failed": result.get('failed', 0),
-            "total": result.get('total', 0),
-            "details": result.get('details', [])
+            "moved": result.get("moved", 0),
+            "failed": result.get("failed", 0),
+            "total": result.get("total", 0),
+            "details": result.get("details", []),
         }
     except Exception as e:
         return {"error": f"Failed to bulk move emails: {str(e)}"}
+
 
 @mcp.tool()
 def bulk_mark_emails_as_read(email_ids: str, mailbox: str = "INBOX", mark_read: bool = True) -> dict:
     """
     Bulk mark emails as read or unread.
-    
+
     Args:
         email_ids: Comma-separated list of email IDs to mark
         mailbox: Mailbox containing the emails (default: INBOX)
         mark_read: True to mark as read, False to mark as unread
-    
+
     Returns:
         Dictionary with marking operation results
     """
@@ -2319,34 +2303,35 @@ def bulk_mark_emails_as_read(email_ids: str, mailbox: str = "INBOX", mark_read: 
 
     try:
         # Parse email IDs
-        id_list = [id.strip() for id in email_ids.split(',') if id.strip()]
-        
+        id_list = [id.strip() for id in email_ids.split(",") if id.strip()]
+
         if not id_list:
             return {"error": "No valid email IDs provided"}
-        
+
         action = "add" if mark_read else "remove"
-        result = email_client.bulk_mark_emails(id_list, '\\Seen', action, mailbox)
-        
+        result = email_client.bulk_mark_emails(id_list, "\\Seen", action, mailbox)
+
         return {
             "status": "success",
-            "marked": result.get('marked', 0),
-            "failed": result.get('failed', 0),
-            "total": result.get('total', 0),
-            "action": "marked_as_read" if mark_read else "marked_as_unread"
+            "marked": result.get("marked", 0),
+            "failed": result.get("failed", 0),
+            "total": result.get("total", 0),
+            "action": "marked_as_read" if mark_read else "marked_as_unread",
         }
     except Exception as e:
         return {"error": f"Failed to bulk mark emails: {str(e)}"}
+
 
 @mcp.tool()
 def bulk_mark_emails_as_important(email_ids: str, mailbox: str = "INBOX", mark_important: bool = True) -> dict:
     """
     Bulk mark emails as important/flagged or remove importance.
-    
+
     Args:
         email_ids: Comma-separated list of email IDs to mark
         mailbox: Mailbox containing the emails (default: INBOX)
         mark_important: True to mark as important, False to remove importance
-    
+
     Returns:
         Dictionary with marking operation results
     """
@@ -2357,23 +2342,24 @@ def bulk_mark_emails_as_important(email_ids: str, mailbox: str = "INBOX", mark_i
 
     try:
         # Parse email IDs
-        id_list = [id.strip() for id in email_ids.split(',') if id.strip()]
-        
+        id_list = [id.strip() for id in email_ids.split(",") if id.strip()]
+
         if not id_list:
             return {"error": "No valid email IDs provided"}
-        
+
         action = "add" if mark_important else "remove"
-        result = email_client.bulk_mark_emails(id_list, '\\Flagged', action, mailbox)
-        
+        result = email_client.bulk_mark_emails(id_list, "\\Flagged", action, mailbox)
+
         return {
             "status": "success",
-            "marked": result.get('marked', 0),
-            "failed": result.get('failed', 0),
-            "total": result.get('total', 0),
-            "action": "marked_as_important" if mark_important else "removed_importance"
+            "marked": result.get("marked", 0),
+            "failed": result.get("failed", 0),
+            "total": result.get("total", 0),
+            "action": "marked_as_important" if mark_important else "removed_importance",
         }
     except Exception as e:
         return {"error": f"Failed to bulk mark emails as important: {str(e)}"}
+
 
 @mcp.tool()
 def bulk_delete_emails(email_ids: str, mailbox: str = "INBOX", permanent: bool = False, confirm: bool = False) -> dict:
@@ -2399,34 +2385,35 @@ def bulk_delete_emails(email_ids: str, mailbox: str = "INBOX", permanent: bool =
             return {"error": "Safety measure: set confirm=True to permanently delete emails", "email_count": "unknown"}
 
         # Parse email IDs
-        id_list = [id.strip() for id in email_ids.split(',') if id.strip()]
+        id_list = [id.strip() for id in email_ids.split(",") if id.strip()]
 
         if not id_list:
             return {"error": "No valid email IDs provided"}
 
         result = email_client.bulk_delete_emails(id_list, mailbox, permanent)
-        
+
         return {
             "status": "success",
-            "deleted": result.get('deleted', 0),
-            "moved": result.get('moved', 0),  # For non-permanent deletion
-            "failed": result.get('failed', 0),
+            "deleted": result.get("deleted", 0),
+            "moved": result.get("moved", 0),  # For non-permanent deletion
+            "failed": result.get("failed", 0),
             "total": len(id_list),
-            "permanent": permanent
+            "permanent": permanent,
         }
     except Exception as e:
         return {"error": f"Failed to bulk delete emails: {str(e)}"}
+
 
 @mcp.tool()
 def apply_filter_rules_optimized(mailbox: str = "INBOX", limit: int = 200, chunk_size: int = 50) -> dict:
     """
     Apply filtering rules to large numbers of emails using optimized bulk processing.
-    
+
     Args:
         mailbox: Mailbox to process (default: INBOX)
         limit: Maximum number of emails to process (default: 200)
         chunk_size: Size of processing chunks for memory management (default: 50)
-    
+
     Returns:
         Summary of optimized rule application
     """
@@ -2436,15 +2423,16 @@ def apply_filter_rules_optimized(mailbox: str = "INBOX", limit: int = 200, chunk
     except Exception as e:
         return {"error": f"Failed to apply filter rules (optimized): {str(e)}"}
 
+
 @mcp.tool()
-def bulk_get_emails(email_ids: str, mailbox: str = "INBOX") -> List[dict]:
+def bulk_get_emails(email_ids: str, mailbox: str = "INBOX") -> list[dict]:
     """
     Efficiently retrieve multiple emails in bulk.
-    
+
     Args:
         email_ids: Comma-separated list of email IDs to retrieve
         mailbox: Mailbox containing the emails (default: INBOX)
-    
+
     Returns:
         List of email objects with full content
     """
@@ -2455,13 +2443,13 @@ def bulk_get_emails(email_ids: str, mailbox: str = "INBOX") -> List[dict]:
 
     try:
         # Parse email IDs
-        id_list = [id.strip() for id in email_ids.split(',') if id.strip()]
-        
+        id_list = [id.strip() for id in email_ids.split(",") if id.strip()]
+
         if not id_list:
             return [{"error": "No valid email IDs provided"}]
-        
+
         emails_dict = email_client.get_bulk_emails(id_list, mailbox)
-        
+
         # Convert to list format expected by MCP tools
         emails_list = []
         for email_id in id_list:
@@ -2469,10 +2457,11 @@ def bulk_get_emails(email_ids: str, mailbox: str = "INBOX") -> List[dict]:
                 emails_list.append(emails_dict[email_id])
             else:
                 emails_list.append({"id": email_id, "error": "Email not found or could not be retrieved"})
-        
+
         return emails_list
     except Exception as e:
         return [{"error": f"Failed to bulk retrieve emails: {str(e)}"}]
+
 
 # MCP Resources
 @mcp.resource("proton://inbox/summary")
@@ -2480,16 +2469,16 @@ def inbox_summary() -> Resource:
     """Get a summary of your inbox"""
     try:
         recent_emails = email_client.search_emails("ALL", "INBOX", 5)
-        summary = f"Recent emails in your Proton inbox:\n\n"
+        summary = "Recent emails in your Proton inbox:\n\n"
         for email_item in recent_emails:
             summary += f"{email_item['subject']} - From: {email_item['from']} ({email_item['date']})\n"
-        
+
         return Resource(
             uri="proton://inbox/summary",
             name="Inbox Summary",
             description="Summary of recent emails in your Proton inbox",
             mimeType="text/plain",
-            text=summary
+            text=summary,
         )
     except Exception as e:
         return Resource(
@@ -2497,8 +2486,9 @@ def inbox_summary() -> Resource:
             name="Inbox Summary",
             description="Error retrieving inbox summary",
             mimeType="text/plain",
-            text=f"Error: {str(e)}"
+            text=f"Error: {str(e)}",
         )
+
 
 # Run the server
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,14 @@ ignore = [
     "S113",   # requests timeout - we set timeouts explicitly
 ]
 
+[tool.bandit]
+exclude_dirs = ["venv", ".venv"]
+skips = [
+    "B101",   # assert usage (fine for this project)
+    "B110",   # try-except-pass in MIME parsing - intentional
+    "B112",   # try-except-continue in MIME parsing - intentional
+]
+
 [tool.mypy]
 python_version = "3.12"
 warn_return_any = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,33 @@
+[tool.ruff]
+target-version = "py312"
+line-length = 120
+
+[tool.ruff.lint]
+select = [
+    "E",    # pycodestyle errors
+    "W",    # pycodestyle warnings
+    "F",    # pyflakes
+    "I",    # isort
+    "B",    # flake8-bugbear
+    "S",    # flake8-bandit (security)
+    "UP",   # pyupgrade
+]
+ignore = [
+    "E501",   # line too long (handled by formatter)
+    "S101",   # assert usage (fine for this project)
+    "S603",   # subprocess calls (not used)
+    "S607",   # partial path to executable (not used)
+]
+
+[tool.ruff.lint.per-file-ignores]
+"proton-email-server.py" = [
+    "S113",   # requests timeout - we set timeouts explicitly
+]
+
+[tool.mypy]
+python_version = "3.12"
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = false
+check_untyped_defs = true
+ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,8 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "proton-email-server.py" = [
+    "S110",   # try-except-pass in MIME parsing - intentional silent skip of malformed parts
+    "S112",   # try-except-continue in MIME parsing - same reason
     "S113",   # requests timeout - we set timeouts explicitly
 ]
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+ruff>=0.8.0
+mypy>=1.13.0
+types-requests>=2.32.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,5 @@
 ruff>=0.8.0
 mypy>=1.13.0
 types-requests>=2.32.0
+bandit>=1.7.0
+pip-audit>=2.7.0


### PR DESCRIPTION
## Summary
- **Bandit** security scanner: runs at medium+ severity (`-ll`), uploads full JSON report as build artifact for detailed review
- **pip-audit** dependency audit: fails the build if any pinned dependency has a known CVE in the OSV database
- Bandit config in `pyproject.toml` skips B101/B110/B112 (same patterns already suppressed in ruff's flake8-bandit rules)
- Both tools added to `requirements-dev.txt`

## Local verification
- Bandit: 0 medium/high findings (5 low — all expected try-except patterns)
- pip-audit: no known vulnerabilities in current dependencies

## Test plan
- [ ] All existing CI jobs still pass (lint, typecheck, syntax)
- [ ] New security scan job passes with no medium+ findings
- [ ] New dependency audit job passes with no CVEs
- [ ] Bandit JSON report artifact is downloadable from the Actions run